### PR TITLE
fix: do not coerce `undefined` to `null` for JSON serialization

### DIFF
--- a/packages/verified-fetch/src/utils/dag-cbor-to-safe-json.ts
+++ b/packages/verified-fetch/src/utils/dag-cbor-to-safe-json.ts
@@ -1,18 +1,5 @@
 import { decode } from 'cborg'
 import { encode } from 'cborg/json'
-import { CID } from 'multiformats/cid'
-import type { TagDecoder } from 'cborg'
-
-// https://github.com/ipfs/go-ipfs/issues/3570#issuecomment-273931692
-const CID_CBOR_TAG = 0x2A
-
-function cidDecoder (bytes: Uint8Array): CID {
-  if (bytes[0] !== 0) {
-    throw new Error('Invalid CID for CBOR tag 42; expected leading 0x00')
-  }
-
-  return CID.decode(bytes.subarray(1)) // ignore leading 0x00
-}
 
 /**
  * Take a `DAG-CBOR` encoded `Uint8Array`, deserialize it as an object and
@@ -20,18 +7,14 @@ function cidDecoder (bytes: Uint8Array): CID {
  * `JSON.parse` without losing any data.
  */
 export function dagCborToSafeJSON (buf: Uint8Array): string {
-  const tags: TagDecoder[] = []
-  tags[CID_CBOR_TAG] = cidDecoder
-
   const obj = decode(buf, {
     allowIndefinite: false,
-    coerceUndefinedToNull: true,
+    coerceUndefinedToNull: false,
     allowNaN: false,
     allowInfinity: false,
     strict: true,
     useMaps: false,
     rejectDuplicateMapKeys: true,
-    tags,
 
     // this is different to `DAG-CBOR` - the reason we disallow BigInts is
     // because we are about to re-encode to `JSON` which does not support


### PR DESCRIPTION
Removes the CID decoder and disallows `undefined` when decoding CBOR as these do not round-trip to JSON.

Expands the test suite to be explicit about the types that are not supported.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
