### PR TITLE
feat: support IPFS/IPNS paths, Gateways, etc

### DIFF
--- a/packages/verified-fetch/src/utils/parse-url-string.ts
+++ b/packages/verified-fetch/src/utils/parse-url-string.ts
@@ -33,7 +33,7 @@ export interface ParsedUrlStringResults {
 const URL_REGEX = /^(?<protocol>ip[fn]s):\/\/(?<cidOrPeerIdOrDnsLink>[^/?]+)\/?(?<path>[^?]*)\??(?<queryString>.*)$/
 const PATH_REGEX = /^\/(?<protocol>ip[fn]s)\/(?<cidOrPeerIdOrDnsLink>[^/?]+)\/?(?<path>[^?]*)\??(?<queryString>.*)$/
 const PATH_GATEWAY_REGEX = /^https?:\/\/(.*[^/])\/(?<protocol>ip[fn]s)\/(?<cidOrPeerIdOrDnsLink>[^/?]+)\/?(?<path>[^?]*)\??(?<queryString>.*)$/
-const SUBDOMAIN_GATEWAY_REGEX = /^https?:\/\/(?<cidOrPeerIdOrDnsLink>[^/$?]+)\.(?<protocol>ip[fn]s)\.([^/?]*)\/?(?<path>[^?]*)\??(?<queryString>.*)$/
+const SUBDOMAIN_GATEWAY_REGEX = /^https?:\/\/(?<cidOrPeerIdOrDnsLink>[^/.?]+)\.(?<protocol>ip[fn]s)\.([^/?]+)\/?(?<path>[^$?]*)\??(?<queryString>.*)$/
 
 function matchURLString (urlString: string): Record<string, string> {
   for (const pattern of [URL_REGEX, PATH_REGEX, PATH_GATEWAY_REGEX, SUBDOMAIN_GATEWAY_REGEX]) {
@@ -44,7 +44,7 @@ function matchURLString (urlString: string): Record<string, string> {
     }
   }
 
-  throw new TypeError(`Invalid URL: ${urlString}, please use ipfs://, ipns://, or gateway URLs only.`)
+  throw new TypeError(`Invalid URL: ${urlString}, please use ipfs://, ipns://, or gateway URLs only`)
 }
 
 /**

--- a/packages/verified-fetch/src/utils/parse-url-string.ts
+++ b/packages/verified-fetch/src/utils/parse-url-string.ts
@@ -44,7 +44,7 @@ function matchURLString (urlString: string): Record<string, string> {
     }
   }
 
-  throw new TypeError(`Invalid URL: ${urlString}, please use ipfs:// or ipns:// URLs only.`)
+  throw new TypeError(`Invalid URL: ${urlString}, please use ipfs://, ipns://, or gateway URLs only.`)
 }
 
 /**

--- a/packages/verified-fetch/src/utils/parse-url-string.ts
+++ b/packages/verified-fetch/src/utils/parse-url-string.ts
@@ -30,10 +30,10 @@ export interface ParsedUrlStringResults {
   query: ParsedUrlQuery
 }
 
-const URL_REGEX = /^(?<protocol>ip[fn]s):\/\/(?<cidOrPeerIdOrDnsLink>[^/$?]+)\/?(?<path>[^$?]*)\??(?<queryString>.*)$/
-const PATH_REGEX = /^\/(?<protocol>ip[fn]s)\/(?<cidOrPeerIdOrDnsLink>[^/$?]+)\/?(?<path>[^$?]*)\??(?<queryString>.*)$/
-const PATH_GATEWAY_REGEX = /^http(s?):\/\/(.*)\/(?<protocol>ip[fn]s)\/(?<cidOrPeerIdOrDnsLink>[^/$?]+)\/?(?<path>[^$?]*)\??(?<queryString>.*)$/
-const SUBDOMAIN_GATEWAY_REGEX = /^http(s?):\/\/(?<cidOrPeerIdOrDnsLink>[^/$?]+)\.(?<protocol>ip[fn]s)\.([^/?]*)\/?(?<path>[^$?]*)\??(?<queryString>.*)$/
+const URL_REGEX = /^(?<protocol>ip[fn]s):\/\/(?<cidOrPeerIdOrDnsLink>[^/?]+)\/?(?<path>[^?]*)\??(?<queryString>.*)$/
+const PATH_REGEX = /^\/(?<protocol>ip[fn]s)\/(?<cidOrPeerIdOrDnsLink>[^/?]+)\/?(?<path>[^?]*)\??(?<queryString>.*)$/
+const PATH_GATEWAY_REGEX = /^https?:\/\/(.*[^/])\/(?<protocol>ip[fn]s)\/(?<cidOrPeerIdOrDnsLink>[^/?]+)\/?(?<path>[^?]*)\??(?<queryString>.*)$/
+const SUBDOMAIN_GATEWAY_REGEX = /^https?:\/\/(?<cidOrPeerIdOrDnsLink>[^/$?]+)\.(?<protocol>ip[fn]s)\.([^/?]*)\/?(?<path>[^?]*)\??(?<queryString>.*)$/
 
 function matchURLString (urlString: string): Record<string, string> {
   for (const pattern of [URL_REGEX, PATH_REGEX, PATH_GATEWAY_REGEX, SUBDOMAIN_GATEWAY_REGEX]) {

--- a/packages/verified-fetch/src/utils/parse-url-string.ts
+++ b/packages/verified-fetch/src/utils/parse-url-string.ts
@@ -33,7 +33,7 @@ export interface ParsedUrlStringResults {
 const URL_REGEX = /^(?<protocol>ip[fn]s):\/\/(?<cidOrPeerIdOrDnsLink>[^/?]+)\/?(?<path>[^?]*)\??(?<queryString>.*)$/
 const PATH_REGEX = /^\/(?<protocol>ip[fn]s)\/(?<cidOrPeerIdOrDnsLink>[^/?]+)\/?(?<path>[^?]*)\??(?<queryString>.*)$/
 const PATH_GATEWAY_REGEX = /^https?:\/\/(.*[^/])\/(?<protocol>ip[fn]s)\/(?<cidOrPeerIdOrDnsLink>[^/?]+)\/?(?<path>[^?]*)\??(?<queryString>.*)$/
-const SUBDOMAIN_GATEWAY_REGEX = /^https?:\/\/(?<cidOrPeerIdOrDnsLink>[^/.?]+)\.(?<protocol>ip[fn]s)\.([^/?]+)\/?(?<path>[^$?]*)\??(?<queryString>.*)$/
+const SUBDOMAIN_GATEWAY_REGEX = /^https?:\/\/(?<cidOrPeerIdOrDnsLink>[^/.?]+)\.(?<protocol>ip[fn]s)\.([^/?]+)\/?(?<path>[^?]*)\??(?<queryString>.*)$/
 
 function matchURLString (urlString: string): Record<string, string> {
   for (const pattern of [URL_REGEX, PATH_REGEX, PATH_GATEWAY_REGEX, SUBDOMAIN_GATEWAY_REGEX]) {

--- a/packages/verified-fetch/test/utils/parse-url-string.spec.ts
+++ b/packages/verified-fetch/test/utils/parse-url-string.spec.ts
@@ -48,7 +48,7 @@ describe('parseUrlString', () => {
           logger
         })
       ).to.eventually.be.rejected
-        .with.property('message', 'Invalid URL: invalid, please use ipfs:// or ipns:// URLs only.')
+        .with.property('message', 'Invalid URL: invalid, please use ipfs://, ipns://, or gateway URLs only')
     })
 
     it('throws for invalid protocols', async () => {
@@ -59,7 +59,7 @@ describe('parseUrlString', () => {
           logger
         })
       ).to.eventually.be.rejected
-        .with.property('message', 'Invalid URL: invalid, please use ipfs:// or ipns:// URLs only.')
+        .with.property('message', 'Invalid URL: invalid, please use ipfs://, ipns://, or gateway URLs only')
     })
 
     it('throws an error if resulting CID is invalid', async () => {

--- a/packages/verified-fetch/test/utils/parse-url-string.spec.ts
+++ b/packages/verified-fetch/test/utils/parse-url-string.spec.ts
@@ -9,6 +9,11 @@ import type { IPNS } from '@helia/ipns'
 import type { ComponentLogger, PeerId } from '@libp2p/interface'
 import type { StubbedInstance } from 'sinon-ts'
 
+const HTTP_PROTOCOLS = [
+  'http',
+  'https'
+]
+
 describe('parseUrlString', () => {
   let logger: ComponentLogger
   let ipns: StubbedInstance<IPNS>
@@ -598,127 +603,131 @@ describe('parseUrlString', () => {
     })
   })
 
-  describe('http://example.com/ipfs/<CID> URLs', () => {
-    let peerId: PeerId
-    let cid: CID
+  HTTP_PROTOCOLS.forEach(proto => {
+    describe(`${proto}://example.com/ipfs/<CID> URLs`, () => {
+      let peerId: PeerId
+      let cid: CID
 
-    beforeEach(async () => {
-      peerId = await createEd25519PeerId()
-      cid = CID.parse('QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm')
-      ipns.resolve.withArgs(matchPeerId(peerId)).resolves({
-        cid,
-        path: ''
+      beforeEach(async () => {
+        peerId = await createEd25519PeerId()
+        cid = CID.parse('QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm')
+        ipns.resolve.withArgs(matchPeerId(peerId)).resolves({
+          cid,
+          path: ''
+        })
       })
-    })
 
-    it('should parse an IPFS Gateway URL with a CID only', async () => {
-      await assertMatchUrl(
-        `http://example.com/ipns/${peerId}`, {
-          protocol: 'ipns',
-          cid: cid.toString(),
-          path: '',
-          query: {}
-        }
-      )
-    })
-
-    it('can parse an IPNS Gateway URL with CID+path', async () => {
-      await assertMatchUrl(
-        `http://example.com/ipns/${peerId}/1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt`, {
-          protocol: 'ipns',
-          cid: cid.toString(),
-          path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
-          query: {}
-        }
-      )
-    })
-
-    it('can parse an IPNS Gateway URL with CID+queryString', async () => {
-      await assertMatchUrl(
-        `http://example.com/ipns/${peerId}?format=car`, {
-          protocol: 'ipns',
-          cid: cid.toString(),
-          path: '',
-          query: {
-            format: 'car'
+      it('should parse an IPFS Gateway URL with a CID only', async () => {
+        await assertMatchUrl(
+          `${proto}://example.com/ipns/${peerId}`, {
+            protocol: 'ipns',
+            cid: cid.toString(),
+            path: '',
+            query: {}
           }
-        }
-      )
-    })
+        )
+      })
 
-    it('can parse an IPNS Gateway URL with CID+path+queryString', async () => {
-      await assertMatchUrl(
-        `http://example.com/ipns/${peerId}/1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt?format=tar`, {
-          protocol: 'ipns',
-          cid: cid.toString(),
-          path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
-          query: {
-            format: 'tar'
+      it('can parse an IPNS Gateway URL with CID+path', async () => {
+        await assertMatchUrl(
+          `${proto}://example.com/ipns/${peerId}/1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt`, {
+            protocol: 'ipns',
+            cid: cid.toString(),
+            path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
+            query: {}
           }
-        }
-      )
+        )
+      })
+
+      it('can parse an IPNS Gateway URL with CID+queryString', async () => {
+        await assertMatchUrl(
+          `${proto}://example.com/ipns/${peerId}?format=car`, {
+            protocol: 'ipns',
+            cid: cid.toString(),
+            path: '',
+            query: {
+              format: 'car'
+            }
+          }
+        )
+      })
+
+      it('can parse an IPNS Gateway URL with CID+path+queryString', async () => {
+        await assertMatchUrl(
+          `${proto}://example.com/ipns/${peerId}/1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt?format=tar`, {
+            protocol: 'ipns',
+            cid: cid.toString(),
+            path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
+            query: {
+              format: 'tar'
+            }
+          }
+        )
+      })
     })
   })
 
-  describe('http://<CID>.ipns.example.com URLs', () => {
-    let peerId: PeerId
-    let cid: CID
+  HTTP_PROTOCOLS.forEach(proto => {
+    describe(`${proto}://<CID>.ipns.example.com URLs`, () => {
+      let peerId: PeerId
+      let cid: CID
 
-    beforeEach(async () => {
-      peerId = await createEd25519PeerId()
-      cid = CID.parse('QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm')
-      ipns.resolve.withArgs(matchPeerId(peerId)).resolves({
-        cid,
-        path: ''
+      beforeEach(async () => {
+        peerId = await createEd25519PeerId()
+        cid = CID.parse('QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm')
+        ipns.resolve.withArgs(matchPeerId(peerId)).resolves({
+          cid,
+          path: ''
+        })
       })
-    })
 
-    it('should parse a IPNS Subdomain Gateway URL with a CID only', async () => {
-      await assertMatchUrl(
-        `http://${peerId}.ipns.example.com`, {
-          protocol: 'ipns',
-          cid: cid.toString(),
-          path: '',
-          query: {}
-        }
-      )
-    })
-
-    it('can parse a IPNS Subdomain Gateway URL with CID+path', async () => {
-      await assertMatchUrl(
-        `http://${peerId}.ipns.example.com/1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt`, {
-          protocol: 'ipns',
-          cid: cid.toString(),
-          path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
-          query: {}
-        }
-      )
-    })
-
-    it('can parse a IPNS Subdomain Gateway URL with CID+queryString', async () => {
-      await assertMatchUrl(
-        `http://${peerId}.ipns.example.com?format=car`, {
-          protocol: 'ipns',
-          cid: cid.toString(),
-          path: '',
-          query: {
-            format: 'car'
+      it('should parse a IPNS Subdomain Gateway URL with a CID only', async () => {
+        await assertMatchUrl(
+          `${proto}://${peerId}.ipns.example.com`, {
+            protocol: 'ipns',
+            cid: cid.toString(),
+            path: '',
+            query: {}
           }
-        }
-      )
-    })
+        )
+      })
 
-    it('can parse a IPNS Subdomain Gateway URL with CID+path+queryString', async () => {
-      await assertMatchUrl(
-        `http://${peerId}.ipns.example.com/1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt?format=tar`, {
-          protocol: 'ipns',
-          cid: cid.toString(),
-          path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
-          query: {
-            format: 'tar'
+      it('can parse a IPNS Subdomain Gateway URL with CID+path', async () => {
+        await assertMatchUrl(
+          `${proto}://${peerId}.ipns.example.com/1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt`, {
+            protocol: 'ipns',
+            cid: cid.toString(),
+            path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
+            query: {}
           }
-        }
-      )
+        )
+      })
+
+      it('can parse a IPNS Subdomain Gateway URL with CID+queryString', async () => {
+        await assertMatchUrl(
+          `${proto}://${peerId}.ipns.example.com?format=car`, {
+            protocol: 'ipns',
+            cid: cid.toString(),
+            path: '',
+            query: {
+              format: 'car'
+            }
+          }
+        )
+      })
+
+      it('can parse a IPNS Subdomain Gateway URL with CID+path+queryString', async () => {
+        await assertMatchUrl(
+          `${proto}://${peerId}.ipns.example.com/1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt?format=tar`, {
+            protocol: 'ipns',
+            cid: cid.toString(),
+            path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
+            query: {
+              format: 'tar'
+            }
+          }
+        )
+      })
     })
   })
 })

--- a/packages/verified-fetch/test/utils/parse-url-string.spec.ts
+++ b/packages/verified-fetch/test/utils/parse-url-string.spec.ts
@@ -752,7 +752,7 @@ describe('parseUrlString', () => {
   })
 
   HTTP_PROTOCOLS.forEach(proto => {
-    describe(`${proto}://<CID>.ipns.example.com URLs`, () => {
+    describe(`${proto}://<key>.ipns.example.com URLs`, () => {
       let peerId: PeerId
       let cid: CID
 

--- a/packages/verified-fetch/test/utils/parse-url-string.spec.ts
+++ b/packages/verified-fetch/test/utils/parse-url-string.spec.ts
@@ -90,49 +90,64 @@ describe('parseUrlString', () => {
     })
 
     it('can parse a URL with CID only', async () => {
-      const result = await parseUrlString({
-        urlString: 'ipfs://QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
-        ipns,
-        logger
-      })
-      expect(result.protocol).to.equal('ipfs')
-      expect(result.cid.toString()).to.equal('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr')
-      expect(result.path).to.equal('')
+      await assertMatchUrl(
+        'ipfs://QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr', {
+          protocol: 'ipfs',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: '',
+          query: {}
+        }
+      )
     })
 
     it('can parse URL with CID+path', async () => {
-      const result = await parseUrlString({
-        urlString: 'ipfs://QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm/1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
-        ipns,
-        logger
-      })
-      expect(result.protocol).to.equal('ipfs')
-      expect(result.cid.toString()).to.equal('QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm')
-      expect(result.path).to.equal('1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt')
+      await assertMatchUrl(
+        'ipfs://QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm/1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt', {
+          protocol: 'ipfs',
+          cid: 'QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm',
+          path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
+          query: {}
+        }
+      )
     })
 
     it('can parse URL with CID+queryString', async () => {
-      const result = await parseUrlString({
-        urlString: 'ipfs://QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm?format=car',
-        ipns,
-        logger
-      })
-      expect(result.protocol).to.equal('ipfs')
-      expect(result.cid.toString()).to.equal('QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm')
-      expect(result.path).to.equal('')
-      expect(result.query).to.deep.equal({ format: 'car' })
+      await assertMatchUrl(
+        'ipfs://QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm?format=car', {
+          protocol: 'ipfs',
+          cid: 'QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm',
+          path: '',
+          query: {
+            format: 'car'
+          }
+        }
+      )
+    })
+
+    it('can parse URL with CID, trailing slash and queryString', async () => {
+      await assertMatchUrl(
+        'ipfs://QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm/?format=car', {
+          protocol: 'ipfs',
+          cid: 'QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm',
+          path: '',
+          query: {
+            format: 'car'
+          }
+        }
+      )
     })
 
     it('can parse URL with CID+path+queryString', async () => {
-      const result = await parseUrlString({
-        urlString: 'ipfs://QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm/1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt?format=tar',
-        ipns,
-        logger
-      })
-      expect(result.protocol).to.equal('ipfs')
-      expect(result.cid.toString()).to.equal('QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm')
-      expect(result.path).to.equal('1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt')
-      expect(result.query).to.deep.equal({ format: 'tar' })
+      await assertMatchUrl(
+        'ipfs://QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm/1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt?format=tar', {
+          protocol: 'ipfs',
+          cid: 'QmdmQXB2mzChmMeKY47C43LxUdg1NDJ5MWcKMKxDu7RgQm',
+          path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
+          query: {
+            format: 'tar'
+          }
+        }
+      )
     })
   })
 
@@ -154,14 +169,14 @@ describe('parseUrlString', () => {
         path: ''
       })
 
-      const result = await parseUrlString({
-        urlString: 'ipns://mydomain.com',
-        ipns,
-        logger
-      })
-      expect(result.protocol).to.equal('ipns')
-      expect(result.cid.toString()).to.equal('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr')
-      expect(result.path).to.equal('')
+      await assertMatchUrl(
+        'ipns://mydomain.com', {
+          protocol: 'ipns',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: '',
+          query: {}
+        }
+      )
     })
 
     it('can parse a URL with DNSLinkDomain+path', async () => {
@@ -170,14 +185,14 @@ describe('parseUrlString', () => {
         path: ''
       })
 
-      const result = await parseUrlString({
-        urlString: 'ipns://mydomain.com/some/path/to/file.txt',
-        ipns,
-        logger
-      })
-      expect(result.protocol).to.equal('ipns')
-      expect(result.cid.toString()).to.equal('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr')
-      expect(result.path).to.equal('some/path/to/file.txt')
+      await assertMatchUrl(
+        'ipns://mydomain.com/some/path/to/file.txt', {
+          protocol: 'ipns',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: 'some/path/to/file.txt',
+          query: {}
+        }
+      )
     })
 
     it('can parse a URL with DNSLinkDomain+queryString', async () => {
@@ -186,15 +201,16 @@ describe('parseUrlString', () => {
         path: ''
       })
 
-      const result = await parseUrlString({
-        urlString: 'ipns://mydomain.com?format=json',
-        ipns,
-        logger
-      })
-      expect(result.protocol).to.equal('ipns')
-      expect(result.cid.toString()).to.equal('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr')
-      expect(result.path).to.equal('')
-      expect(result.query).to.deep.equal({ format: 'json' })
+      await assertMatchUrl(
+        'ipns://mydomain.com?format=json', {
+          protocol: 'ipns',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: '',
+          query: {
+            format: 'json'
+          }
+        }
+      )
     })
 
     it('can parse a URL with DNSLinkDomain+path+queryString', async () => {
@@ -203,15 +219,34 @@ describe('parseUrlString', () => {
         path: ''
       })
 
-      const result = await parseUrlString({
-        urlString: 'ipns://mydomain.com/some/path/to/file.txt?format=json',
-        ipns,
-        logger: defaultLogger()
+      await assertMatchUrl(
+        'ipns://mydomain.com/some/path/to/file.txt?format=json', {
+          protocol: 'ipns',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: 'some/path/to/file.txt',
+          query: {
+            format: 'json'
+          }
+        }
+      )
+    })
+
+    it('can parse a URL with DNSLinkDomain+directoryPath+queryString', async () => {
+      ipns.resolveDns.withArgs('mydomain.com').resolves({
+        cid: CID.parse('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr'),
+        path: ''
       })
-      expect(result.protocol).to.equal('ipns')
-      expect(result.cid.toString()).to.equal('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr')
-      expect(result.path).to.equal('some/path/to/file.txt')
-      expect(result.query).to.deep.equal({ format: 'json' })
+
+      await assertMatchUrl(
+        'ipns://mydomain.com/some/path/to/dir/?format=json', {
+          protocol: 'ipns',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: 'some/path/to/dir/',
+          query: {
+            format: 'json'
+          }
+        }
+      )
     })
   })
 
@@ -399,14 +434,15 @@ describe('parseUrlString', () => {
         cid: CID.parse('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr'),
         path: ''
       })
-      const result = await parseUrlString({
-        urlString: `ipns://${testPeerId}`,
-        ipns,
-        logger
-      })
-      expect(result.protocol).to.equal('ipns')
-      expect(result.cid.toString()).to.equal('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr')
-      expect(result.path).to.equal('')
+
+      await assertMatchUrl(
+        `ipns://${testPeerId}`, {
+          protocol: 'ipns',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: '',
+          query: {}
+        }
+      )
     })
 
     it('can parse a URL with PeerId+path', async () => {
@@ -414,14 +450,15 @@ describe('parseUrlString', () => {
         cid: CID.parse('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr'),
         path: ''
       })
-      const result = await parseUrlString({
-        urlString: `ipns://${testPeerId}/some/path/to/file.txt`,
-        ipns,
-        logger
-      })
-      expect(result.protocol).to.equal('ipns')
-      expect(result.cid.toString()).to.equal('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr')
-      expect(result.path).to.equal('some/path/to/file.txt')
+
+      await assertMatchUrl(
+        `ipns://${testPeerId}/some/path/to/file.txt`, {
+          protocol: 'ipns',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: 'some/path/to/file.txt',
+          query: {}
+        }
+      )
     })
 
     it('can parse a URL with PeerId+path with a trailing slash', async () => {
@@ -429,14 +466,15 @@ describe('parseUrlString', () => {
         cid: CID.parse('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr'),
         path: ''
       })
-      const result = await parseUrlString({
-        urlString: `ipns://${testPeerId}/some/path/to/dir/`,
-        ipns,
-        logger
-      })
-      expect(result.protocol).to.equal('ipns')
-      expect(result.cid.toString()).to.equal('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr')
-      expect(result.path).to.equal('some/path/to/dir/')
+
+      await assertMatchUrl(
+        `ipns://${testPeerId}/some/path/to/dir/`, {
+          protocol: 'ipns',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: 'some/path/to/dir/',
+          query: {}
+        }
+      )
     })
 
     it('can parse a URL with PeerId+queryString', async () => {
@@ -444,15 +482,17 @@ describe('parseUrlString', () => {
         cid: CID.parse('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr'),
         path: ''
       })
-      const result = await parseUrlString({
-        urlString: `ipns://${testPeerId}?fomat=dag-cbor`,
-        ipns,
-        logger
-      })
-      expect(result.protocol).to.equal('ipns')
-      expect(result.cid.toString()).to.equal('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr')
-      expect(result.path).to.equal('')
-      expect(result.query).to.deep.equal({ fomat: 'dag-cbor' })
+
+      await assertMatchUrl(
+        `ipns://${testPeerId}?format=dag-cbor`, {
+          protocol: 'ipns',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: '',
+          query: {
+            format: 'dag-cbor'
+          }
+        }
+      )
     })
 
     it('can parse a URL with PeerId+path+queryString', async () => {
@@ -460,15 +500,17 @@ describe('parseUrlString', () => {
         cid: CID.parse('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr'),
         path: ''
       })
-      const result = await parseUrlString({
-        urlString: `ipns://${testPeerId}/some/path/to/file.txt?fomat=dag-cbor`,
-        ipns,
-        logger
-      })
-      expect(result.protocol).to.equal('ipns')
-      expect(result.cid.toString()).to.equal('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr')
-      expect(result.path).to.equal('some/path/to/file.txt')
-      expect(result.query).to.deep.equal({ fomat: 'dag-cbor' })
+
+      await assertMatchUrl(
+        `ipns://${testPeerId}/some/path/to/file.txt?format=dag-cbor`, {
+          protocol: 'ipns',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: 'some/path/to/file.txt',
+          query: {
+            format: 'dag-cbor'
+          }
+        }
+      )
     })
 
     it('should parse an ipns:// url with a path that resolves to a CID with a path', async () => {
@@ -482,16 +524,14 @@ describe('parseUrlString', () => {
         path: recordPath
       })
 
-      await expect(parseUrlString({
-        urlString: `ipns://${peerId}/${requestPath}`,
-        ipns,
-        logger
-      })).to.eventually.deep.equal({
-        protocol: 'ipns',
-        path: `${recordPath}/${requestPath}`,
-        cid,
-        query: {}
-      })
+      await assertMatchUrl(
+        `ipns://${peerId}/${requestPath}`, {
+          protocol: 'ipns',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: `${recordPath}/${requestPath}`,
+          query: {}
+        }
+      )
     })
 
     it('should parse an ipns:// url with a path that resolves to a CID with a path with a trailing slash', async () => {
@@ -505,16 +545,14 @@ describe('parseUrlString', () => {
         path: recordPath
       })
 
-      await expect(parseUrlString({
-        urlString: `ipns://${peerId}/${requestPath}`,
-        ipns,
-        logger
-      })).to.eventually.deep.equal({
-        protocol: 'ipns',
-        path: 'foo/bar/baz.txt',
-        cid,
-        query: {}
-      })
+      await assertMatchUrl(
+        `ipns://${peerId}/${requestPath}`, {
+          protocol: 'ipns',
+          path: 'foo/bar/baz.txt',
+          cid: cid.toString(),
+          query: {}
+        }
+      )
     })
 
     it('should parse an ipns:// url with a path that resolves to a CID with a path with a trailing slash', async () => {
@@ -528,16 +566,14 @@ describe('parseUrlString', () => {
         path: recordPath
       })
 
-      await expect(parseUrlString({
-        urlString: `ipns://${peerId}/${requestPath}`,
-        ipns,
-        logger
-      })).to.eventually.deep.equal({
-        protocol: 'ipns',
-        path: 'foo/bar/baz/qux.txt',
-        cid,
-        query: {}
-      })
+      await assertMatchUrl(
+        `ipns://${peerId}/${requestPath}`, {
+          protocol: 'ipns',
+          path: 'foo/bar/baz/qux.txt',
+          cid: cid.toString(),
+          query: {}
+        }
+      )
     })
   })
 
@@ -576,6 +612,17 @@ describe('parseUrlString', () => {
       )
     })
 
+    it('can parse an IPNS Path with PeerId+directoryPath', async () => {
+      await assertMatchUrl(
+        `/ipns/${peerId}/path/to/dir/`, {
+          protocol: 'ipns',
+          cid: cid.toString(),
+          path: 'path/to/dir/',
+          query: {}
+        }
+      )
+    })
+
     it('can parse an IPNS Path with PeerId+queryString', async () => {
       await assertMatchUrl(
         `/ipns/${peerId}?format=car`, {
@@ -595,6 +642,19 @@ describe('parseUrlString', () => {
           protocol: 'ipns',
           cid: cid.toString(),
           path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
+          query: {
+            format: 'tar'
+          }
+        }
+      )
+    })
+
+    it('can parse an IPNS Path with PeerId+directoryPath+queryString', async () => {
+      await assertMatchUrl(
+        `/ipns/${peerId}/path/to/dir/?format=tar`, {
+          protocol: 'ipns',
+          cid: cid.toString(),
+          path: 'path/to/dir/',
           query: {
             format: 'tar'
           }
@@ -639,6 +699,17 @@ describe('parseUrlString', () => {
         )
       })
 
+      it('can parse an IPNS Gateway URL with CID+directoryPath', async () => {
+        await assertMatchUrl(
+          `${proto}://example.com/ipns/${peerId}/path/to/dir/`, {
+            protocol: 'ipns',
+            cid: cid.toString(),
+            path: 'path/to/dir/',
+            query: {}
+          }
+        )
+      })
+
       it('can parse an IPNS Gateway URL with CID+queryString', async () => {
         await assertMatchUrl(
           `${proto}://example.com/ipns/${peerId}?format=car`, {
@@ -658,6 +729,19 @@ describe('parseUrlString', () => {
             protocol: 'ipns',
             cid: cid.toString(),
             path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
+            query: {
+              format: 'tar'
+            }
+          }
+        )
+      })
+
+      it('can parse an IPNS Gateway URL with CID+directoryPath+queryString', async () => {
+        await assertMatchUrl(
+          `${proto}://example.com/ipns/${peerId}/path/to/dir/?format=tar`, {
+            protocol: 'ipns',
+            cid: cid.toString(),
+            path: 'path/to/dir/',
             query: {
               format: 'tar'
             }
@@ -703,6 +787,17 @@ describe('parseUrlString', () => {
         )
       })
 
+      it('can parse a IPNS Subdomain Gateway URL with CID+directoryPath', async () => {
+        await assertMatchUrl(
+          `${proto}://${peerId}.ipns.example.com/path/to/dir/`, {
+            protocol: 'ipns',
+            cid: cid.toString(),
+            path: 'path/to/dir/',
+            query: {}
+          }
+        )
+      })
+
       it('can parse a IPNS Subdomain Gateway URL with CID+queryString', async () => {
         await assertMatchUrl(
           `${proto}://${peerId}.ipns.example.com?format=car`, {
@@ -722,6 +817,19 @@ describe('parseUrlString', () => {
             protocol: 'ipns',
             cid: cid.toString(),
             path: '1 - Barrel - Part 1/1 - Barrel - Part 1 - alt.txt',
+            query: {
+              format: 'tar'
+            }
+          }
+        )
+      })
+
+      it('can parse a IPNS Subdomain Gateway URL with CID+directoryPath+queryString', async () => {
+        await assertMatchUrl(
+          `${proto}://${peerId}.ipns.example.com/path/to/dir/?format=tar`, {
+            protocol: 'ipns',
+            cid: cid.toString(),
+            path: 'path/to/dir/',
             query: {
               format: 'tar'
             }


### PR DESCRIPTION
Adds support for fetching resources in the form:

- IPFS Path, e.g. `/ipfs/<CID>`
- IPNS Path, e.g. `/ipns/<PeerId>`
- IPFS Gateway Path, e.g. `http://example.com/ipfs/<CID>`
- IPNS Gateway Path, e.g. `http://example.com/ipns/<PeerId>`
- IPFS Subdomain Gateway Path, e.g. `http://<CID>.ipfs.example.com`
- IPNS Subdomain Gateway Path, e.g. `http://<PeerId>.ipns.example.com`

Notes:

- Supports paths & queries as per `ipfs://` and `ipns://` URLs.
- Uses all available methods to resolve a given CID to some content - it does not, for example, when given a subdomain gateway path, restrict downloading the blocks from only that subdomain gateway

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
