### PR TITLE
chore: unskip IPNS test

### DIFF
--- a/packages/verified-fetch/test/accept-header.spec.ts
+++ b/packages/verified-fetch/test/accept-header.spec.ts
@@ -268,7 +268,7 @@ describe('accept header', () => {
     expect(resp.headers.get('content-type')).to.equal('application/octet-stream')
   })
 
-  it.skip('should support fetching IPNS records', async () => {
+  it('should support fetching IPNS records', async () => {
     const peerId = await createEd25519PeerId()
     const obj = {
       hello: 'world'
@@ -288,7 +288,7 @@ describe('accept header', () => {
     expect(resp.headers.get('content-type')).to.equal('application/vnd.ipfs.ipns-record')
     const buf = await resp.arrayBuffer()
 
-    expect(buf).to.equalBytes(marshal(record))
+    expect(new Uint8Array(buf)).to.equalBytes(marshal(record))
   })
 
   shouldNotAcceptCborWith({


### PR DESCRIPTION
This module supports retrieving raw IPNS records so the test for this can be unskipped.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
