### PR TITLE
fix!: move dnsResolvers to options

### DIFF
--- a/packages/verified-fetch/README.md
+++ b/packages/verified-fetch/README.md
@@ -181,7 +181,8 @@ import { dnsJsonOverHttps, dnsOverHttps } from '@helia/ipns/dns-resolvers'
 
 const fetch = await createVerifiedFetch({
   gateways: ['https://trustless-gateway.link'],
-  routers: ['http://delegated-ipfs.dev'],
+  routers: ['http://delegated-ipfs.dev']
+}, {
   dnsResolvers: [
     dnsJsonOverHttps('https://my-dns-resolver.example.com/dns-json'),
     dnsOverHttps('https://my-dns-resolver.example.com/dns-query')

--- a/packages/verified-fetch/src/index.ts
+++ b/packages/verified-fetch/src/index.ts
@@ -152,7 +152,8 @@
  *
  * const fetch = await createVerifiedFetch({
  *   gateways: ['https://trustless-gateway.link'],
- *   routers: ['http://delegated-ipfs.dev'],
+ *   routers: ['http://delegated-ipfs.dev']
+ * }, {
  *   dnsResolvers: [
  *     dnsJsonOverHttps('https://my-dns-resolver.example.com/dns-json'),
  *     dnsOverHttps('https://my-dns-resolver.example.com/dns-query')
@@ -607,18 +608,6 @@ export interface VerifiedFetch {
 export interface CreateVerifiedFetchInit {
   gateways: string[]
   routers?: string[]
-
-  /**
-   * In order to parse DNSLink records, we need to resolve DNS queries. You can
-   * pass a list of DNS resolvers that we will provide to the @helia/ipns
-   * instance for you. You must construct them using the `dnsJsonOverHttps` or
-   * `dnsOverHttps` functions exported from `@helia/ipns/dns-resolvers`.
-   *
-   * We use cloudflare and google's dnsJsonOverHttps resolvers by default.
-   *
-   * @default [dnsJsonOverHttps('https://mozilla.cloudflare-dns.com/dns-query'),dnsJsonOverHttps('https://dns.google/resolve')]
-   */
-  dnsResolvers?: DNSResolver[]
 }
 
 export interface CreateVerifiedFetchOptions {
@@ -631,6 +620,18 @@ export interface CreateVerifiedFetchOptions {
    * @default undefined
    */
   contentTypeParser?: ContentTypeParser
+
+  /**
+   * In order to parse DNSLink records, we need to resolve DNS queries. You can
+   * pass a list of DNS resolvers that we will provide to the @helia/ipns
+   * instance for you. You must construct them using the `dnsJsonOverHttps` or
+   * `dnsOverHttps` functions exported from `@helia/ipns/dns-resolvers`.
+   *
+   * We use cloudflare and google's dnsJsonOverHttps resolvers by default.
+   *
+   * @default [dnsJsonOverHttps('https://mozilla.cloudflare-dns.com/dns-query'),dnsJsonOverHttps('https://dns.google/resolve')]
+   */
+  dnsResolvers?: DNSResolver[]
 }
 
 /**
@@ -676,7 +677,7 @@ export interface VerifiedFetchInit extends RequestInit, ProgressOptions<BubbledP
 export async function createVerifiedFetch (init?: Helia | CreateVerifiedFetchInit, options?: CreateVerifiedFetchOptions): Promise<VerifiedFetch> {
   let dnsResolvers: DNSResolver[] | undefined
   if (!isHelia(init)) {
-    dnsResolvers = init?.dnsResolvers
+    dnsResolvers = options?.dnsResolvers
     init = await createHeliaHTTP({
       blockBrokers: [
         trustlessGateway({

--- a/packages/verified-fetch/test/custom-dns-resolvers.spec.ts
+++ b/packages/verified-fetch/test/custom-dns-resolvers.spec.ts
@@ -23,7 +23,8 @@ describe('custom dns-resolvers', () => {
     customDnsResolver.returns(Promise.resolve('/ipfs/QmVP2ip92jQuMDezVSzQBWDqWFbp9nyCHNQSiciRauPLDg'))
 
     const fetch = await createVerifiedFetch({
-      gateways: ['http://127.0.0.1:8080'],
+      gateways: ['http://127.0.0.1:8080']
+    }, {
       dnsResolvers: [customDnsResolver]
     })
     // error of walking the CID/dag because we haven't actually added the block to the blockstore


### PR DESCRIPTION
## Description

As per https://github.com/ipfs/helia/pull/445#issuecomment-1980812623, this PR changes the API of `createVerifiedFetch` so as to allow passing a custom instance of Helia (for example, with a custom blockstore) in addition to customising the `dnsResolvers`. 


## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
