### PR TITLE
chore: add tests for directory redirects for gateways

### DIFF
--- a/packages/verified-fetch/test/verified-fetch.spec.ts
+++ b/packages/verified-fetch/test/verified-fetch.spec.ts
@@ -160,6 +160,60 @@ describe('@helia/verifed-fetch', () => {
       expect(ipfsResponse.url).to.equal(`ipfs://${res.cid}/foo`)
     })
 
+    it('should return a 301 with a trailing slash when a gateway directory is requested without a trailing slash', async () => {
+      const finalRootFileContent = new Uint8Array([0x01, 0x02, 0x03])
+
+      const fs = unixfs(helia)
+      const res = await last(fs.addAll([{
+        path: 'foo/index.html',
+        content: finalRootFileContent
+      }], {
+        wrapWithDirectory: true
+      }))
+
+      if (res == null) {
+        throw new Error('Import failed')
+      }
+
+      const stat = await fs.stat(res.cid)
+      expect(stat.type).to.equal('directory')
+
+      const ipfsResponse = await verifiedFetch.fetch(`https://ipfs.local/ipfs/${res.cid}/foo`, {
+        redirect: 'manual'
+      })
+      expect(ipfsResponse).to.be.ok()
+      expect(ipfsResponse.status).to.equal(301)
+      expect(ipfsResponse.headers.get('location')).to.equal(`https://ipfs.local/ipfs/${res.cid}/foo/`)
+      expect(ipfsResponse.url).to.equal(`https://ipfs.local/ipfs/${res.cid}/foo`)
+    })
+
+    it('should return a 301 with a trailing slash when a subdomain gateway directory is requested without a trailing slash', async () => {
+      const finalRootFileContent = new Uint8Array([0x01, 0x02, 0x03])
+
+      const fs = unixfs(helia)
+      const res = await last(fs.addAll([{
+        path: 'foo/index.html',
+        content: finalRootFileContent
+      }], {
+        wrapWithDirectory: true
+      }))
+
+      if (res == null) {
+        throw new Error('Import failed')
+      }
+
+      const stat = await fs.stat(res.cid)
+      expect(stat.type).to.equal('directory')
+
+      const ipfsResponse = await verifiedFetch.fetch(`https://${res.cid}.ipfs.local/foo`, {
+        redirect: 'manual'
+      })
+      expect(ipfsResponse).to.be.ok()
+      expect(ipfsResponse.status).to.equal(301)
+      expect(ipfsResponse.headers.get('location')).to.equal(`https://${res.cid}.ipfs.local/foo/`)
+      expect(ipfsResponse.url).to.equal(`https://${res.cid}.ipfs.local/foo`)
+    })
+
     it('should simulate following a redirect to a path with a slash when a directory is requested without a trailing slash', async () => {
       const finalRootFileContent = new Uint8Array([0x01, 0x02, 0x03])
 


### PR DESCRIPTION
Adds tests to ensure gateway and subdomain gateways return redirects that are browser-cacheable.

Refs: https://github.com/ipfs-shipyard/helia-service-worker-gateway/issues/62#issuecomment-1981379184

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
