### PR TITLE
fix: byte range request end should never equal file size

### DIFF
--- a/packages/verified-fetch/src/utils/request-headers.ts
+++ b/packages/verified-fetch/src/utils/request-headers.ts
@@ -23,29 +23,32 @@ export function getHeader (headers: HeadersInit | undefined, header: string): st
  * 2. the start index of the range. // inclusive
  * 3. the end index of the range. // inclusive
  */
+// eslint-disable-next-line complexity
 export function calculateByteRangeIndexes (start: number | undefined, end: number | undefined, fileSize?: number): { byteSize?: number, start?: number, end?: number } {
-  if (start != null && end != null) {
-    if (start > end) {
-      throw new Error('Invalid range: Range-start index is greater than range-end index.')
-    }
-    if (end >= (fileSize ?? Infinity)) {
-      throw new Error('Invalid range: Range-end index is greater than or equal to the size of the file.')
-    }
+  if ((start ?? 0) > (end ?? Infinity)) {
+    throw new Error('Invalid range: Range-start index is greater than range-end index.')
+  }
+  if (start != null && (end ?? 0) >= (fileSize ?? Infinity)) {
+    throw new Error('Invalid range: Range-end index is greater than or equal to the size of the file.')
+  }
+  if (start == null && (end ?? 0) > (fileSize ?? Infinity)) {
+    throw new Error('Invalid range: Range-end index is greater than the size of the file.')
+  }
+  if (start != null && start < 0) {
+    throw new Error('Invalid range: Range-start index cannot be negative.')
+  }
 
+  if (start != null && end != null) {
     return { byteSize: end - start + 1, start, end }
   } else if (start == null && end != null) {
     // suffix byte range requested
     if (fileSize == null) {
       return { end }
     }
-    if (end > fileSize) {
-      throw new Error('Invalid range: Range-end index is greater than the size of the file.')
-    }
     if (end === fileSize) {
       return { byteSize: fileSize, start: 0, end: fileSize - 1 }
     }
-    const result = { byteSize: end, start: fileSize - end + 1, end: fileSize - 1 }
-    return result
+    return { byteSize: end, start: fileSize - end, end: fileSize - 1 }
   } else if (start != null && end == null) {
     if (fileSize == null) {
       // we only have the start index, and no fileSize, so we can't return a valid range.
@@ -56,6 +59,5 @@ export function calculateByteRangeIndexes (start: number | undefined, end: numbe
     return { byteSize, start, end }
   }
 
-  // both start and end are undefined
-  return { byteSize: fileSize }
+  return { byteSize: fileSize, start: 0, end: fileSize != null ? fileSize - 1 : 0 }
 }

--- a/packages/verified-fetch/src/utils/request-headers.ts
+++ b/packages/verified-fetch/src/utils/request-headers.ts
@@ -26,7 +26,10 @@ export function getHeader (headers: HeadersInit | undefined, header: string): st
 export function calculateByteRangeIndexes (start: number | undefined, end: number | undefined, fileSize?: number): { byteSize?: number, start?: number, end?: number } {
   if (start != null && end != null) {
     if (start > end) {
-      throw new Error('Invalid range')
+      throw new Error('Invalid range: Range-start index is greater than range-end index.')
+    }
+    if (end >= (fileSize ?? Infinity)) {
+      throw new Error('Invalid range: Range-end index is greater than or equal to the size of the file.')
     }
 
     return { byteSize: end - start + 1, start, end }
@@ -35,14 +38,21 @@ export function calculateByteRangeIndexes (start: number | undefined, end: numbe
     if (fileSize == null) {
       return { end }
     }
-    const result = { byteSize: end, start: fileSize - end + 1, end: fileSize }
+    if (end > fileSize) {
+      throw new Error('Invalid range: Range-end index is greater than the size of the file.')
+    }
+    if (end === fileSize) {
+      return { byteSize: fileSize, start: 0, end: fileSize - 1 }
+    }
+    const result = { byteSize: end, start: fileSize - end + 1, end: fileSize - 1 }
     return result
   } else if (start != null && end == null) {
     if (fileSize == null) {
+      // we only have the start index, and no fileSize, so we can't return a valid range.
       return { start }
     }
-    const byteSize = fileSize - start + 1
-    const end = fileSize
+    const end = fileSize - 1
+    const byteSize = fileSize - start
     return { byteSize, start, end }
   }
 

--- a/packages/verified-fetch/src/utils/response-headers.ts
+++ b/packages/verified-fetch/src/utils/response-headers.ts
@@ -7,12 +7,19 @@
 export function getContentRangeHeader ({ byteStart, byteEnd, byteSize }: { byteStart: number | undefined, byteEnd: number | undefined, byteSize: number | undefined }): string {
   const total = byteSize ?? '*' // if we don't know the total size, we should use *
 
+  if ((byteEnd ?? 0) >= (byteSize ?? Infinity)) {
+    throw new Error('Invalid range: Range-end index is greater than or equal to the size of the file.')
+  }
+  if ((byteStart ?? 0) >= (byteSize ?? Infinity)) {
+    throw new Error('Invalid range: Range-start index is greater than or equal to the size of the file.')
+  }
+
   if (byteStart != null && byteEnd == null) {
     // only byteStart in range
     if (byteSize == null) {
       return `bytes */${total}`
     }
-    return `bytes ${byteStart}-${byteSize}/${byteSize}`
+    return `bytes ${byteStart}-${byteSize - 1}/${byteSize}`
   }
 
   if (byteStart == null && byteEnd != null) {
@@ -20,7 +27,10 @@ export function getContentRangeHeader ({ byteStart, byteEnd, byteSize }: { byteS
     if (byteSize == null) {
       return `bytes */${total}`
     }
-    return `bytes ${byteSize - byteEnd + 1}-${byteSize}/${byteSize}`
+    const end = byteSize - 1
+    const start = end - byteEnd + 1
+
+    return `bytes ${start}-${end}/${byteSize}`
   }
 
   if (byteStart == null && byteEnd == null) {

--- a/packages/verified-fetch/test/range-requests.spec.ts
+++ b/packages/verified-fetch/test/range-requests.spec.ts
@@ -70,13 +70,13 @@ describe('range requests', () => {
         },
         {
           byteSize: 8,
-          contentRange: 'bytes 4-11/11',
+          contentRange: 'bytes 4-10/11',
           rangeHeader: 'bytes=4-',
-          bytes: new Uint8Array([3, 4, 5, 6, 7, 8, 9, 10])
+          bytes: new Uint8Array([4, 5, 6, 7, 8, 9, 10])
         },
         {
           byteSize: 9,
-          contentRange: 'bytes 3-11/11',
+          contentRange: 'bytes 2-10/11',
           rangeHeader: 'bytes=-9',
           bytes: new Uint8Array([2, 3, 4, 5, 6, 7, 8, 9, 10])
         }

--- a/packages/verified-fetch/test/utils/byte-range-context.spec.ts
+++ b/packages/verified-fetch/test/utils/byte-range-context.spec.ts
@@ -45,9 +45,9 @@ describe('ByteRangeContext', () => {
   const array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
   const uint8arrayRangeTests = [
     // full ranges:
-    { type: 'Uint8Array', range: 'bytes=0-11', contentRange: 'bytes 0-11/11', body: new Uint8Array(array), expected: new Uint8Array(array) },
-    { type: 'Uint8Array', range: 'bytes=-11', contentRange: 'bytes 1-11/11', body: new Uint8Array(array), expected: new Uint8Array(array) },
-    { type: 'Uint8Array', range: 'bytes=0-', contentRange: 'bytes 0-11/11', body: new Uint8Array(array), expected: new Uint8Array(array) },
+    { type: 'Uint8Array', range: 'bytes=0-10', contentRange: 'bytes 0-10/11', body: new Uint8Array(array), expected: new Uint8Array(array) },
+    { type: 'Uint8Array', range: 'bytes=-11', contentRange: 'bytes 0-10/11', body: new Uint8Array(array), expected: new Uint8Array(array) },
+    { type: 'Uint8Array', range: 'bytes=0-', contentRange: 'bytes 0-10/11', body: new Uint8Array(array), expected: new Uint8Array(array) },
 
     // partial ranges:
     { type: 'Uint8Array', range: 'bytes=0-1', contentRange: 'bytes 0-1/11', body: new Uint8Array(array), expected: new Uint8Array([1, 2]) },
@@ -60,13 +60,13 @@ describe('ByteRangeContext', () => {
     { type: 'Uint8Array', range: 'bytes=0-8', contentRange: 'bytes 0-8/11', body: new Uint8Array(array), expected: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9]) },
     { type: 'Uint8Array', range: 'bytes=0-9', contentRange: 'bytes 0-9/11', body: new Uint8Array(array), expected: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) },
     { type: 'Uint8Array', range: 'bytes=0-10', contentRange: 'bytes 0-10/11', body: new Uint8Array(array), expected: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) },
-    { type: 'Uint8Array', range: 'bytes=1-', contentRange: 'bytes 1-11/11', body: new Uint8Array(array), expected: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) },
-    { type: 'Uint8Array', range: 'bytes=2-', contentRange: 'bytes 2-11/11', body: new Uint8Array(array), expected: new Uint8Array([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) },
-    { type: 'Uint8Array', range: 'bytes=-2', contentRange: 'bytes 10-11/11', body: new Uint8Array(array), expected: new Uint8Array(array.slice(-2)) },
+    { type: 'Uint8Array', range: 'bytes=1-', contentRange: 'bytes 1-10/11', body: new Uint8Array(array), expected: new Uint8Array([2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) },
+    { type: 'Uint8Array', range: 'bytes=2-', contentRange: 'bytes 2-10/11', body: new Uint8Array(array), expected: new Uint8Array([3, 4, 5, 6, 7, 8, 9, 10, 11]) },
+    { type: 'Uint8Array', range: 'bytes=-2', contentRange: 'bytes 9-10/11', body: new Uint8Array(array), expected: new Uint8Array(array.slice(-2)) },
 
     // single byte ranges:
     { type: 'Uint8Array', range: 'bytes=1-1', contentRange: 'bytes 1-1/11', body: new Uint8Array(array), expected: new Uint8Array(array.slice(1, 2)) },
-    { type: 'Uint8Array', range: 'bytes=-1', contentRange: 'bytes 11-11/11', body: new Uint8Array(array), expected: new Uint8Array(array.slice(-1)) }
+    { type: 'Uint8Array', range: 'bytes=-1', contentRange: 'bytes 10-10/11', body: new Uint8Array(array), expected: new Uint8Array(array.slice(-1)) }
 
   ]
   const validRanges = [
@@ -138,12 +138,11 @@ describe('ByteRangeContext', () => {
         })
         const stat = await fs.stat(cid)
         context.setFileSize(stat.fileSize)
-
         context.setBody(await getBodyStream(context.offset, context.length))
         const response = new Response(context.getBody())
         const bodyResult = await response.arrayBuffer()
-        expect(new Uint8Array(bodyResult)).to.deep.equal(expected)
         expect(context.contentRangeHeaderValue).to.equal(contentRange)
+        expect(new Uint8Array(bodyResult)).to.deep.equal(expected)
       })
     })
   })

--- a/packages/verified-fetch/test/utils/request-headers.spec.ts
+++ b/packages/verified-fetch/test/utils/request-headers.spec.ts
@@ -34,7 +34,7 @@ describe('request-headers', () => {
       // Range: bytes=5-
       { start: 5, end: undefined, fileSize: 10, expected: { byteSize: 5, start: 5, end: 9 } },
       // Range: bytes=-5
-      { start: undefined, end: 5, fileSize: 10, expected: { byteSize: 5, start: 6, end: 9 } },
+      { start: undefined, end: 5, fileSize: 10, expected: { byteSize: 5, start: 5, end: 9 } },
       // Range: bytes=0-0
       { start: 0, end: 0, fileSize: 10, expected: { byteSize: 1, start: 0, end: 0 } },
       // Range: bytes=5- with unknown filesize
@@ -44,9 +44,14 @@ describe('request-headers', () => {
       // Range: bytes=0-0 with unknown filesize
       { start: 0, end: 0, fileSize: undefined, expected: { byteSize: 1, start: 0, end: 0 } },
       // Range: bytes=-9 & fileSize=11
-      { start: undefined, end: 9, fileSize: 11, expected: { byteSize: 9, start: 3, end: 10 } },
+      { start: undefined, end: 9, fileSize: 11, expected: { byteSize: 9, start: 2, end: 10 } },
       // Range: bytes=-11 & fileSize=11
-      { start: undefined, end: 11, fileSize: 11, expected: { byteSize: 11, start: 0, end: 10 } }
+      { start: undefined, end: 11, fileSize: 11, expected: { byteSize: 11, start: 0, end: 10 } },
+      // Range: bytes=-2 & fileSize=11
+      { start: undefined, end: 2, fileSize: 11, expected: { byteSize: 2, start: 9, end: 10 } },
+      // Range request with no range (added for coverage)
+      { start: undefined, end: undefined, fileSize: 10, expected: { byteSize: 10, start: 0, end: 9 } }
+
     ]
     testCases.forEach(({ start, end, fileSize, expected }) => {
       it(`should return expected result for bytes=${start ?? ''}-${end ?? ''} and fileSize=${fileSize}`, () => {
@@ -57,6 +62,7 @@ describe('request-headers', () => {
       expect(() => calculateByteRangeIndexes(5, 4, 10)).to.throw('Invalid range: Range-start index is greater than range-end index.')
       expect(() => calculateByteRangeIndexes(5, 11, 11)).to.throw('Invalid range: Range-end index is greater than or equal to the size of the file.')
       expect(() => calculateByteRangeIndexes(undefined, 12, 11)).to.throw('Invalid range: Range-end index is greater than the size of the file.')
+      expect(() => calculateByteRangeIndexes(-1, 5, 10)).to.throw('Invalid range: Range-start index cannot be negative.')
     })
   })
 })

--- a/packages/verified-fetch/test/utils/request-headers.spec.ts
+++ b/packages/verified-fetch/test/utils/request-headers.spec.ts
@@ -32,9 +32,9 @@ describe('request-headers', () => {
   describe('calculateByteRangeIndexes', () => {
     const testCases = [
       // Range: bytes=5-
-      { start: 5, end: undefined, fileSize: 10, expected: { byteSize: 6, start: 5, end: 10 } },
+      { start: 5, end: undefined, fileSize: 10, expected: { byteSize: 5, start: 5, end: 9 } },
       // Range: bytes=-5
-      { start: undefined, end: 5, fileSize: 10, expected: { byteSize: 5, start: 6, end: 10 } },
+      { start: undefined, end: 5, fileSize: 10, expected: { byteSize: 5, start: 6, end: 9 } },
       // Range: bytes=0-0
       { start: 0, end: 0, fileSize: 10, expected: { byteSize: 1, start: 0, end: 0 } },
       // Range: bytes=5- with unknown filesize
@@ -44,18 +44,19 @@ describe('request-headers', () => {
       // Range: bytes=0-0 with unknown filesize
       { start: 0, end: 0, fileSize: undefined, expected: { byteSize: 1, start: 0, end: 0 } },
       // Range: bytes=-9 & fileSize=11
-      { start: undefined, end: 9, fileSize: 11, expected: { byteSize: 9, start: 3, end: 11 } },
-      // Range: bytes=0-11 & fileSize=11
-      { start: 0, end: 11, fileSize: 11, expected: { byteSize: 12, start: 0, end: 11 } }
+      { start: undefined, end: 9, fileSize: 11, expected: { byteSize: 9, start: 3, end: 10 } },
+      // Range: bytes=-11 & fileSize=11
+      { start: undefined, end: 11, fileSize: 11, expected: { byteSize: 11, start: 0, end: 10 } }
     ]
     testCases.forEach(({ start, end, fileSize, expected }) => {
       it(`should return expected result for bytes=${start ?? ''}-${end ?? ''} and fileSize=${fileSize}`, () => {
-        const result = calculateByteRangeIndexes(start, end, fileSize)
-        expect(result).to.deep.equal(expected)
+        expect(calculateByteRangeIndexes(start, end, fileSize)).to.deep.equal(expected)
       })
     })
     it('throws error for invalid range', () => {
-      expect(() => calculateByteRangeIndexes(5, 4, 10)).to.throw('Invalid range')
+      expect(() => calculateByteRangeIndexes(5, 4, 10)).to.throw('Invalid range: Range-start index is greater than range-end index.')
+      expect(() => calculateByteRangeIndexes(5, 11, 11)).to.throw('Invalid range: Range-end index is greater than or equal to the size of the file.')
+      expect(() => calculateByteRangeIndexes(undefined, 12, 11)).to.throw('Invalid range: Range-end index is greater than the size of the file.')
     })
   })
 })

--- a/packages/verified-fetch/test/utils/response-headers.spec.ts
+++ b/packages/verified-fetch/test/utils/response-headers.spec.ts
@@ -11,11 +11,11 @@ describe('response-headers', () => {
     })
 
     it('should return correct content range header when only byteEnd and byteSize are provided', () => {
-      expect(getContentRangeHeader({ byteStart: undefined, byteEnd: 9, byteSize: 11 })).to.equal('bytes 3-11/11')
+      expect(getContentRangeHeader({ byteStart: undefined, byteEnd: 9, byteSize: 11 })).to.equal('bytes 2-10/11')
     })
 
     it('should return correct content range header when only byteStart and byteSize are provided', () => {
-      expect(getContentRangeHeader({ byteStart: 5, byteEnd: undefined, byteSize: 11 })).to.equal('bytes 5-11/11')
+      expect(getContentRangeHeader({ byteStart: 5, byteEnd: undefined, byteSize: 11 })).to.equal('bytes 5-10/11')
     })
 
     it('should return correct content range header when only byteStart is provided', () => {
@@ -28,6 +28,13 @@ describe('response-headers', () => {
 
     it('should return content range header with when only byteSize is provided', () => {
       expect(getContentRangeHeader({ byteStart: undefined, byteEnd: undefined, byteSize: 50 })).to.equal('bytes */50')
+    })
+
+    it('should not allow range-end to equal or exceed the size of the file', () => {
+      expect(() => getContentRangeHeader({ byteStart: 0, byteEnd: 11, byteSize: 11 })).to.throw('Invalid range') // byteEnd is equal to byteSize
+      expect(() => getContentRangeHeader({ byteStart: undefined, byteEnd: 11, byteSize: 11 })).to.throw('Invalid range') // byteEnd is equal to byteSize
+      expect(() => getContentRangeHeader({ byteStart: undefined, byteEnd: 12, byteSize: 11 })).to.throw('Invalid range') // byteEnd is greater than byteSize
+      expect(() => getContentRangeHeader({ byteStart: 11, byteEnd: undefined, byteSize: 11 })).to.throw('Invalid range') // byteEnd is greater than byteSize
     })
   })
 })


### PR DESCRIPTION
- fix: request-headers byte range parsing
- fix: response-headers byte parsing
- fix: request-headers
- fix: byteRangeContext tests
- fix: range-requests tests

## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
Fix byte range parsing

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Byte range requests (`<range-start>-<range-end>/<size>`) should never be in a state where `<range-end>` is greater than or equal to `<size>`. This PR fixes the byte range parsing in the request and response headers to ensure that the range is always valid.


## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->
More info in https://github.com/ipfs-shipyard/helia-service-worker-gateway/pull/122#issuecomment-2005215744


## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
