### PR TITLE
fix: aborted signals throw libp2p AbortError

### DIFF
--- a/packages/verified-fetch/README.md
+++ b/packages/verified-fetch/README.md
@@ -615,7 +615,7 @@ Known Errors that can be thrown:
 1. `TypeError` - If the resource argument is not a string, CID, or CID string.
 2. `TypeError` - If the options argument is passed and not an object.
 3. `TypeError` - If the options argument is passed and is malformed.
-4. `AbortError` - If the content request is aborted due to user aborting provided AbortSignal.
+4. `AbortError` - If the content request is aborted due to user aborting provided AbortSignal. Note that this is a `AbortError` from `@libp2p/interface` and not the standard `AbortError` from the Fetch API.
 
 # Install
 

--- a/packages/verified-fetch/src/utils/get-stream-from-async-iterable.ts
+++ b/packages/verified-fetch/src/utils/get-stream-from-async-iterable.ts
@@ -1,6 +1,6 @@
+import { AbortError, type ComponentLogger } from '@libp2p/interface'
 import { CustomProgressEvent } from 'progress-events'
 import type { VerifiedFetchInit } from '../index.js'
-import type { ComponentLogger } from '@libp2p/interface'
 
 /**
  * Converts an async iterator of Uint8Array bytes to a stream and returns the first chunk of bytes
@@ -24,7 +24,7 @@ export async function getStreamFromAsyncIterable (iterator: AsyncIterable<Uint8A
     async pull (controller) {
       const { value, done } = await reader.next()
       if (options?.signal?.aborted === true) {
-        controller.error(new Error(options.signal.reason ?? 'signal aborted by user'))
+        controller.error(new AbortError(options.signal.reason ?? 'signal aborted by user'))
         controller.close()
         return
       }

--- a/packages/verified-fetch/src/verified-fetch.ts
+++ b/packages/verified-fetch/src/verified-fetch.ts
@@ -552,7 +552,7 @@ export class VerifiedFetch {
       const codecHandler = this.codecHandlers[cid.code]
 
       if (codecHandler == null) {
-        return notSupportedResponse(`Support for codec with code ${cid.code} is not yet implemented. Please open an issue at https://github.com/ipfs/helia/issues/new`)
+        return notSupportedResponse(`Support for codec with code ${cid.code} is not yet implemented. Please open an issue at https://github.com/ipfs/helia-verified-fetch/issues/new`)
       }
       this.log.trace('calling handler "%s"', codecHandler.name)
 


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

fix: aborted signals throw libp2p AbortError

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Fixes #25, specifically https://github.com/ipfs/helia-verified-fetch/issues/25#issuecomment-2014852934

### Summary of changes:

* signal aborts throw `AbortError` from `@libp2p/interface` instead of returning a Response object
    * Updated README.md to mention that this AbortError is not the typical DOMException AbortError thrown by native `fetch`
* updated the URL for not implemented codec requests to point to the correct repo
* added tests to ensure that aborts during `.stat` and `.cat` are handled correctly

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

N/A

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
