### PR TITLE
fix: decodeURIComponent on path parts

### DIFF
--- a/packages/verified-fetch/src/utils/parse-url-string.ts
+++ b/packages/verified-fetch/src/utils/parse-url-string.ts
@@ -276,5 +276,5 @@ function joinPaths (resolvedPath: string | undefined, urlPath: string): string {
     path = path.substring(1)
   }
 
-  return path // .split('/').map(decodeURIComponent).join('/')
+  return path.split('/').map(decodeURIComponent).join('/')
 }

--- a/packages/verified-fetch/src/utils/parse-url-string.ts
+++ b/packages/verified-fetch/src/utils/parse-url-string.ts
@@ -276,5 +276,5 @@ function joinPaths (resolvedPath: string | undefined, urlPath: string): string {
     path = path.substring(1)
   }
 
-  return path
+  return path // .split('/').map(decodeURIComponent).join('/')
 }

--- a/packages/verified-fetch/test/utils/parse-url-string.spec.ts
+++ b/packages/verified-fetch/test/utils/parse-url-string.spec.ts
@@ -339,6 +339,20 @@ describe('parseUrlString', () => {
         }
       )
     })
+
+    // tests for https://github.com/ipfs-shipyard/service-worker-gateway/issues/83 issue
+    it('can parse an IPFS path with encodedURIComponents', async () => {
+      const rawPathLabel = "Plan_d'exécution_du_second_étage_de_l'hôtel_de_Brionne_(dessin)_De_Cotte_2503c_–_Gallica_2011_(adjusted).jpg.webp"
+      await assertMatchUrl(
+        `/ipfs/QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr/I/${encodeURIComponent(rawPathLabel)}`, {
+          protocol: 'ipfs',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          // path with decoded component
+          path: `I/${rawPathLabel}`,
+          query: {}
+        }
+      )
+    })
   })
 
   describe('http://example.com/ipfs/<CID> URLs', () => {


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

fix: decodeURIComponent on path parts

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Fixes an issue where we were not properly handling encoded URI components in URLs.

fixes https://github.com/ipfs-shipyard/service-worker-gateway/issues/83

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

This PR is first submitted with failing src (TDD) tests to demonstrate the issue. Then the fix is applied and the tests are updated to pass.

### Without the fix, with tests:

```bash
> npx aegir test --build true --bail false

...

  311 passing (357ms)
  2 pending
  2 failing

  1) parseUrlString
       /ipfs/<CID> URLs
         can parse an IPFS path with encodedURIComponents:

      AssertionError: expected 'I/Plan_d\'ex%C3%A9cution_du_second_%C…' to equal 'I/Plan_d\'exécution_du_second_étage_d…'
      + expected - actual

      -I/Plan_d'ex%C3%A9cution_du_second_%C3%A9tage_de_l'h%C3%B4tel_de_Brionne_(dessin)_De_Cotte_2503c_%E2%80%93_Gallica_2011_(adjusted).jpg.webp
      +I/Plan_d'exécution_du_second_étage_de_l'hôtel_de_Brionne_(dessin)_De_Cotte_2503c_–_Gallica_2011_(adjusted).jpg.webp

      at assertMatchUrl (file:///Users/sgtpooki/code/work/protocol.ai/ipfs/helia-verified-fetch/packages/verified-fetch/test/utils/parse-url-string.spec.ts:36:28)
      at Context.<anonymous> (file:///Users/sgtpooki/code/work/protocol.ai/ipfs/helia-verified-fetch/packages/verified-fetch/test/utils/parse-url-string.spec.ts:346:7)

  2) @helia/verifed-fetch
       encoded URI paths
         should decode encoded URI paths:

      AssertionError: expected 502 to equal 200
      + expected - actual

      -502
      +200

      at Context.<anonymous> (file:///Users/sgtpooki/code/work/protocol.ai/ipfs/helia-verified-fetch/packages/verified-fetch/test/verified-fetch.spec.ts:745:30)
```

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
