### PR TITLE
fix: remove redundant abort controller

### DIFF
--- a/packages/verified-fetch/src/verified-fetch.ts
+++ b/packages/verified-fetch/src/verified-fetch.ts
@@ -446,15 +446,6 @@ export class VerifiedFetch {
   }
 
   /**
-   *
-   * TODO: Should we use 400, 408, 418, or 425, or throw and not even return a response?
-   */
-  private async abortHandler (opController: AbortController): Promise<void> {
-    this.log.error('signal aborted by user')
-    opController.abort('signal aborted by user')
-  }
-
-  /**
    * We're starting to get to the point where we need a queue or pipeline of
    * operations to perform and a single place to handle errors.
    *
@@ -466,12 +457,6 @@ export class VerifiedFetch {
     this.log('fetch %s', resource)
 
     const options = convertOptions(opts)
-
-    const opController = new AbortController()
-    if (options?.signal != null) {
-      options.signal.onabort = this.abortHandler.bind(this, opController)
-      options.signal = opController.signal
-    }
 
     options?.onProgress?.(new CustomProgressEvent<CIDDetail>('verified-fetch:request:start', { resource }))
 


### PR DESCRIPTION
The signal from this abort controller replaces any user-supplied signal in forward operations.

When the user supplied signal aborts we call abort on the abort controller, aborting it's signal.

We do not call `.abort()` on the abort controller for any other reason, therefore it can be removed and the user-supplied abort signal can be passed through unmodified.

The redundant abort controller's signal also has the default limit on the number of event listeners so it causes `"possible EventEmitter memory leak detected"` warnings in node which people frequently mistake for an error and file issues about.

This manifests itself in `helia-http-gateway` as:

```
(node:58297) MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. Use events.setMaxListeners() to increase limit
    at [kNewListener] (node:internal/event_target:572:17)
    at [kNewListener] (node:internal/abort_controller:241:24)
    at EventTarget.addEventListener (node:internal/event_target:685:23)
    at anySignal (file:///Users/alex/Documents/Workspaces/ipfs/helia-http-gateway-sessions/node_modules/any-signal/dist/src/index.js:21:20)
    at raceBlockRetrievers (file:///Users/alex/Documents/Workspaces/ipfs/helia-http-gateway-sessions/node_modules/@helia/utils/dist/src/utils/networked-storage.js:187:20)
    at NetworkedStorage.get (file:///Users/alex/Documents/Workspaces/ipfs/helia-http-gateway-sessions/node_modules/@helia/utils/dist/src/utils/networked-storage.js:87:33)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async BlockStorage.get (file:///Users/alex/Documents/Workspaces/ipfs/helia-http-gateway-sessions/node_modules/@helia/utils/dist/src/storage.js:68:20)
    at async file:///Users/alex/Documents/Workspaces/ipfs/helia-http-gateway-sessions/node_modules/ipfs-unixfs-exporter/dist/src/resolvers/unixfs-v1/content/file.js:60:27
```

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
