### PR TITLE
fix: pass url and body to badRequestResponse

### DIFF
--- a/packages/verified-fetch/src/verified-fetch.ts
+++ b/packages/verified-fetch/src/verified-fetch.ts
@@ -147,17 +147,17 @@ export class VerifiedFetch {
    */
   private async handleIPNSRecord ({ resource, cid, path, options }: FetchHandlerFunctionArg): Promise<Response> {
     if (path !== '' || !resource.startsWith('ipns://')) {
-      return badRequestResponse('Invalid IPNS name')
+      return badRequestResponse(resource, 'Invalid IPNS name')
     }
 
     let peerId: PeerId
 
     try {
       peerId = peerIdFromString(resource.replace('ipns://', ''))
-    } catch (err) {
+    } catch (err: any) {
       this.log.error('could not parse peer id from IPNS url %s', resource)
 
-      return badRequestResponse('Invalid IPNS name')
+      return badRequestResponse(resource, err)
     }
 
     // since this call happens after parseResource, we've already resolved the


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
chore: pass url and body to badRequestResponse

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

fixes #27

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

Simple fix making sure we pass the resource and body to `badRequestResponse`.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
