### PR TITLE
fix: identity CIDs use contentTypeParser

### DIFF
--- a/packages/verified-fetch/package.json
+++ b/packages/verified-fetch/package.json
@@ -97,7 +97,7 @@
     "@sgtpooki/file-type": "^1.0.1",
     "@types/sinon": "^17.0.3",
     "aegir": "^42.2.5",
-    "blockstore-core": "^4.4.0",
+    "blockstore-core": "^4.4.1",
     "browser-readablestream-to-it": "^2.0.5",
     "datastore-core": "^9.2.9",
     "helia": "^4.1.0",

--- a/packages/verified-fetch/src/verified-fetch.ts
+++ b/packages/verified-fetch/src/verified-fetch.ts
@@ -450,7 +450,7 @@ export class VerifiedFetch {
         this.log.error('error parsing content type', err)
       }
     }
-    this.log.trace('setting content type to "%s"', contentType)
+    this.log.trace('setting content type to "%s"', contentType ?? defaultContentType)
     response.headers.set('content-type', contentType ?? defaultContentType)
   }
 

--- a/packages/verified-fetch/src/verified-fetch.ts
+++ b/packages/verified-fetch/src/verified-fetch.ts
@@ -423,18 +423,13 @@ export class VerifiedFetch {
     // if the user has specified an `Accept` header that corresponds to a raw
     // type, honour that header, so for example they don't request
     // `application/vnd.ipld.raw` but get `application/octet-stream`
-    const overriddenContentType = getOverridenRawContentType({ headers: options?.headers, accept })
-    if (overriddenContentType != null) {
-      response.headers.set('content-type', overriddenContentType)
-    } else {
-      await this.setContentType(result, path, response)
-    }
+    await this.setContentType(result, path, response, getOverridenRawContentType({ headers: options?.headers, accept }))
 
     return response
   }
 
-  private async setContentType (bytes: Uint8Array, path: string, response: Response): Promise<void> {
-    let contentType = 'application/octet-stream'
+  private async setContentType (bytes: Uint8Array, path: string, response: Response, defaultContentType = 'application/octet-stream'): Promise<void> {
+    let contentType: string | undefined
 
     if (this.contentTypeParser != null) {
       try {
@@ -456,7 +451,7 @@ export class VerifiedFetch {
       }
     }
     this.log.trace('setting content type to "%s"', contentType)
-    response.headers.set('content-type', contentType)
+    response.headers.set('content-type', contentType ?? defaultContentType)
   }
 
   /**

--- a/packages/verified-fetch/test/fixtures/create-offline-helia.ts
+++ b/packages/verified-fetch/test/fixtures/create-offline-helia.ts
@@ -1,12 +1,13 @@
 import { Helia as HeliaClass } from '@helia/utils'
 import { MemoryBlockstore } from 'blockstore-core'
+import { IdentityBlockstore } from 'blockstore-core/identity'
 import { MemoryDatastore } from 'datastore-core'
 import type { HeliaHTTPInit } from '@helia/http'
 import type { Helia } from '@helia/interface'
 
 export async function createHelia (init: Partial<HeliaHTTPInit> = {}): Promise<Helia> {
   const datastore = new MemoryDatastore()
-  const blockstore = new MemoryBlockstore()
+  const blockstore = new IdentityBlockstore(new MemoryBlockstore())
 
   const helia = new HeliaClass({
     datastore,


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
fix: identity CIDs use contentTypeParser

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

latest update of `@helia/verified-fetch` caused failing tests in service-worker-gateway: https://github.com/ipfs-shipyard/service-worker-gateway/pull/187

Fixes https://github.com/ipfs/helia-verified-fetch/issues/48

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

This change normalizes how we handle setting content-type for raw CIDs and identity CIDs and was required to ensure that the content-type is set correctly for identity CIDs.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
