### PR TITLE
fix: missing paths returns 404 instead of 502

### DIFF
--- a/packages/verified-fetch/src/verified-fetch.ts
+++ b/packages/verified-fetch/src/verified-fetch.ts
@@ -316,7 +316,7 @@ export class VerifiedFetch {
       terminalElement = pathDetails.terminalElement
     } catch (err: any) {
       options?.signal?.throwIfAborted()
-      if (['ERR_NO_PROP', 'ERR_NO_TERMINAL_ELEMENT'].includes(err.code)) {
+      if (['ERR_NO_PROP', 'ERR_NO_TERMINAL_ELEMENT', 'ERR_NOT_FOUND'].includes(err.code)) {
         return notFoundResponse(resource.toString())
       }
       this.log.error('error walking path %s', path, err)

--- a/packages/verified-fetch/test/verified-fetch.spec.ts
+++ b/packages/verified-fetch/test/verified-fetch.spec.ts
@@ -837,5 +837,23 @@ describe('@helia/verifed-fetch', () => {
       const resp = await verifiedFetch.fetch(`http://example.com/ipfs/${cid}/foo/i-do-not-exist`)
       expect(resp.status).to.equal(404)
     })
+
+    it('returns a 404 when walking dag-pb for non-existent path', async () => {
+      const fs = unixfs(helia)
+
+      const res = await last(fs.addAll([{
+        path: 'index.html',
+        content: Uint8Array.from([0x01, 0x02, 0x03])
+      }], {
+        wrapWithDirectory: true
+      }))
+
+      if (res == null) {
+        throw new Error('Import failed')
+      }
+
+      const resp = await verifiedFetch.fetch(`ipfs://${res.cid}/does/not/exist`)
+      expect(resp.status).to.equal(404)
+    })
   })
 })


### PR DESCRIPTION
Fixes #53

## Notes

When initially writing the test for this, I discovered a bug when trying to create a dag-pb CID, reported as https://github.com/ipfs/helia/issues/506

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
