### PR TITLE
chore: start running CI again

### DIFF
--- a/.github/workflows/js-test-and-release.yml
+++ b/.github/workflows/js-test-and-release.yml
@@ -19,9 +19,10 @@ concurrency:
 
 jobs:
   js-test-and-release:
-    uses: pl-strflt/uci/.github/workflows/js-test-and-release.yml@v0.0
+    uses: ipdxco/unified-github-workflows/.github/workflows/js-test-and-release.yml@v1.0
     secrets:
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       UCI_GITHUB_TOKEN: ${{ secrets.UCI_GITHUB_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The `pl-strflt` org has been renamed `ipdxco`, the `uci` repo has been renamed `unified-github-workflows` and someone deleted the `v0.0` tag so update to the new versions.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
