### PR TITLE
refactor: IPFS_NS_MAP from gateway-conformance v6

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -23,12 +23,12 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       # 3. Download the gateway-conformance fixtures using ipfs/gateway-conformance action
       # This will prevent us from needing to install `docker` on the github runner
       - name: Download gateway-conformance fixtures
-        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.5.1
+        uses: ipfs/gateway-conformance/.github/actions/extract-fixtures@v0.6
         # working-directory: ./packages/gateway-conformance
         with:
           output: ./packages/gateway-conformance/dist/src/fixtures/data/gateway-conformance-fixtures

--- a/packages/gateway-conformance/src/conformance.spec.ts
+++ b/packages/gateway-conformance/src/conformance.spec.ts
@@ -6,6 +6,7 @@ import { prefixLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import { execa } from 'execa'
 import { Agent, setGlobalDispatcher } from 'undici'
+import { GWC_IMAGE } from './constants.js'
 
 const logger = prefixLogger('gateway-conformance')
 
@@ -316,7 +317,8 @@ describe('@helia/verified-fetch - gateway conformance', function () {
         log('Using custom gateway-conformance binary at %s', binaryPath)
         return
       }
-      const { stdout, stderr } = await execa('go', ['install', 'github.com/ipfs/gateway-conformance/cmd/gateway-conformance@latest'], { reject: true })
+      const gwcVersion = GWC_IMAGE.split(':').pop()
+      const { stdout, stderr } = await execa('go', ['install', `github.com/ipfs/gateway-conformance/cmd/gateway-conformance@${gwcVersion}`], { reject: true })
       log(stdout)
       log.error(stderr)
     })

--- a/packages/gateway-conformance/src/constants.ts
+++ b/packages/gateway-conformance/src/constants.ts
@@ -1,1 +1,1 @@
-export const GWC_IMAGE = process.env.GWC_IMAGE ?? 'ghcr.io/ipfs/gateway-conformance:v0.5.1'
+export const GWC_IMAGE = process.env.GWC_IMAGE ?? 'ghcr.io/ipfs/gateway-conformance:v0.6.0'

--- a/packages/gateway-conformance/src/fixtures/kubo-mgmt.ts
+++ b/packages/gateway-conformance/src/fixtures/kubo-mgmt.ts
@@ -53,7 +53,7 @@ function getExecaOptions ({ cwd, ipfsNsMap, kuboRepoDir }: { cwd?: string, ipfsN
 async function downloadFixtures (force = false): Promise<void> {
   if (!force) {
     // if the fixtures are already downloaded, we don't need to download them again
-    const allFixtures = await fg.glob([`${GWC_FIXTURES_PATH}/**/*.car`, `${GWC_FIXTURES_PATH}/**/*.ipns-record`, `${GWC_FIXTURES_PATH}/dnslinks.json`])
+    const allFixtures = await fg.glob([`${GWC_FIXTURES_PATH}/**/*.car`, `${GWC_FIXTURES_PATH}/**/*.ipns-record`, `${GWC_FIXTURES_PATH}/dnslinks.IPFS_NS_MAP`])
     if (allFixtures.length > 0) {
       log('Fixtures already downloaded')
       return
@@ -106,11 +106,7 @@ export async function loadFixtures (kuboRepoDir: string): Promise<string> {
     await datastore.put(dhtKey, dhtRecord.serialize())
   }
 
-  const json = await readFile(`${GWC_FIXTURES_PATH}/dnslinks.json`, 'utf-8')
-  const { subdomains, domains } = JSON.parse(json)
-  const subdomainDnsLinks = Object.entries(subdomains).map(([key, value]) => `${key}.localhost%3A${3441}:${value}`).join(',')
-  const domainDnsLinks = Object.entries(domains).map(([key, value]) => `${key}:${value}`).join(',')
-  const ipfsNsMap = `${domainDnsLinks},${subdomainDnsLinks}`
+  const ipfsNsMap = await readFile(`${GWC_FIXTURES_PATH}/dnslinks.IPFS_NS_MAP`, 'utf-8')
 
   return ipfsNsMap
 }


### PR DESCRIPTION
This PR switches to v6 with changes from https://github.com/ipfs/gateway-conformance/pull/211

## Notes

- `IPFS_NS_MAP` handling refactored: No need to generate env from `dnslink.json`, a fixture in desired format is already provided, and we no longer mix subdomains with DNSLink tests, which also simplifies code

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
