### PR TITLE
feat: use the waterworks trustless gateway by default

### DIFF
--- a/packages/verified-fetch/src/index.ts
+++ b/packages/verified-fetch/src/index.ts
@@ -799,7 +799,7 @@ export async function createVerifiedFetch (init?: Helia | CreateVerifiedFetchIni
       routers: [
         ...(init?.routers ?? ['https://delegated-ipfs.dev']).map((routerUrl) => delegatedHTTPRouting(routerUrl)),
         httpGatewayRouting({
-          gateways: init?.gateways ?? []
+          gateways: init?.gateways ?? ['https://trustless-gateway.link']
         })
       ],
       dns: createDns(init?.dnsResolvers)


### PR DESCRIPTION
## Title

As discussed in person, this changes the default configuration to use the waterworks trustless gateway. 

This should increase retrieval success for users with the default config. 

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
