### PR TITLE
docs: change cidv0 to cidv1 in the readme

### DIFF
--- a/packages/verified-fetch/README.md
+++ b/packages/verified-fetch/README.md
@@ -522,7 +522,7 @@ This module attempts to act as similarly to the `fetch()` API as possible.
 
 This library supports the following methods of fetching web3 content from IPFS:
 
-1. IPFS protocol: `ipfs://<cidv0>` & `ipfs://<cidv0>`
+1. IPFS protocol: `ipfs://<cidv0>` & `ipfs://<cidv1>`
 2. IPNS protocol: `ipns://<peerId>` & `ipns://<publicKey>` & `ipns://<hostUri_Supporting_DnsLink_TxtRecords>`
 3. CID instances: An actual CID instance `CID.parse('bafy...')`
 

--- a/packages/verified-fetch/src/index.ts
+++ b/packages/verified-fetch/src/index.ts
@@ -493,7 +493,7 @@
  *
  * This library supports the following methods of fetching web3 content from IPFS:
  *
- * 1. IPFS protocol: `ipfs://<cidv0>` & `ipfs://<cidv0>`
+ * 1. IPFS protocol: `ipfs://<cidv0>` & `ipfs://<cidv1>`
  * 2. IPNS protocol: `ipns://<peerId>` & `ipns://<publicKey>` & `ipns://<hostUri_Supporting_DnsLink_TxtRecords>`
  * 3. CID instances: An actual CID instance `CID.parse('bafy...')`
  *


### PR DESCRIPTION
I'm just starting with IPFS, but I'm assuming it's not supposed to say "`cidv0` & `cidv0`"