### PR TITLE
fix: allow passing cid encoded ipns keys

### DIFF
--- a/packages/verified-fetch/src/utils/parse-url-string.ts
+++ b/packages/verified-fetch/src/utils/parse-url-string.ts
@@ -1,4 +1,5 @@
 import { peerIdFromString } from '@libp2p/peer-id'
+import { base36 } from 'multiformats/bases/base36'
 import { CID } from 'multiformats/cid'
 import { TLRU } from './tlru.js'
 import type { RequestFormatShorthand } from '../types.js'
@@ -177,7 +178,7 @@ export async function parseUrlString ({ urlString, ipns, logger }: ParseUrlStrin
       let peerId: PeerId | undefined
       try {
         // try resolving as an IPNS name
-        peerId = peerIdFromString(cidOrPeerIdOrDnsLink)
+        peerId = peerIdFromString(cidOrPeerIdOrDnsLink, base36.decoder)
         if (peerId.publicKey == null) {
           throw new TypeError('cidOrPeerIdOrDnsLink contains no public key')
         }

--- a/packages/verified-fetch/test/utils/parse-url-string.spec.ts
+++ b/packages/verified-fetch/test/utils/parse-url-string.spec.ts
@@ -4,6 +4,7 @@ import { defaultLogger } from '@libp2p/logger'
 import { peerIdFromPrivateKey } from '@libp2p/peer-id'
 import { type Answer } from '@multiformats/dns'
 import { expect } from 'aegir/chai'
+import { base36 } from 'multiformats/bases/base36'
 import { CID } from 'multiformats/cid'
 import { match } from 'sinon'
 import { stubInterface } from 'sinon-ts'
@@ -76,7 +77,7 @@ describe('parseUrlString', () => {
           ipns,
           logger
         })
-      ).to.eventually.be.rejected.with.property('message', 'Could not parse PeerId in ipns url "mydomain.com", Please pass a multibase decoder for strings that do not start with "1" or "Q"')
+      ).to.eventually.be.rejected.with.property('message', 'Could not parse PeerId in ipns url "mydomain.com", Unable to decode multibase string "mydomain.com", base36 decoder only supports inputs prefixed with k')
     })
   })
 
@@ -161,7 +162,7 @@ describe('parseUrlString', () => {
 
       await expect(parseUrlString({ urlString: 'ipns://mydomain.com', ipns, logger })).to.eventually.be.rejected
         .with.property('errors').that.deep.equals([
-          new TypeError('Could not parse PeerId in ipns url "mydomain.com", Please pass a multibase decoder for strings that do not start with "1" or "Q"'),
+          new TypeError('Could not parse PeerId in ipns url "mydomain.com", Unable to decode multibase string "mydomain.com", base36 decoder only supports inputs prefixed with k'),
           new Error('Unexpected failure from ipns dns query')
         ])
     })
@@ -459,10 +460,13 @@ describe('parseUrlString', () => {
 
   describe('ipns://<peerId> URLs', () => {
     let testPeerId: PeerId
+    let base36CidPeerId: string
 
     beforeEach(async () => {
       const key = await generateKeyPair('Ed25519')
       testPeerId = peerIdFromPrivateKey(key)
+
+      base36CidPeerId = key.publicKey.toCID().toString(base36)
     })
 
     it('handles invalid PeerIds', async () => {
@@ -496,6 +500,23 @@ describe('parseUrlString', () => {
 
       await assertMatchUrl(
         `ipns://${testPeerId}`, {
+          protocol: 'ipns',
+          cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
+          path: '',
+          query: {}
+        }
+      )
+    })
+
+    it('can parse a base36 PeerId CID', async () => {
+      ipns.resolve.withArgs(matchPeerId(testPeerId)).resolves({
+        cid: CID.parse('QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr'),
+        path: '',
+        record: ipnsRecordStub({ peerId: testPeerId })
+      })
+
+      await assertMatchUrl(
+        `ipns://${base36CidPeerId}`, {
           protocol: 'ipns',
           cid: 'QmQJ8fxavY54CUsxMSx9aE9Rdcmvhx8awJK2jzJp4iAqCr',
           path: '',


### PR DESCRIPTION
## Description

- Fixes a bug whereby passing a base36 encoded IPNS key, e.g. `ipns://k51qzi5uqu5dhp48cti0590jyvwgxssrii0zdf19pyfsxwoqomqvfg6bg8qj3s`, throws an error: helia:verified-fetch:parse-url-string:error could not parse PeerId string "k51qzi5uqu5dhp48cti0590jyvwgxssrii0zdf19pyfsxwoqomqvfg6bg8qj3s" +0ms InvalidParametersError: Please pass a multibase decoder for strings that do not start with "1" or "Q" 

## Depends on

https://github.com/libp2p/js-libp2p/pull/2773


## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
