### PR TITLE
chore: use grouping for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,17 @@ updates:
   commit-message:
     prefix: "deps"
     prefix-development: "deps(dev)"
+  groups:
+    helia-deps: # group all deps that should be updated when Helia deps need updated
+      patterns:
+        - "*helia*"
+        - "*libp2p*"
+        - "*multiformats*"
+    store-deps: # group all blockstore and datastore updates (interface & impl)
+      patterns:
+        - "*blockstore*"
+        - "*datastore*"
+    kubo-deps: # group kubo, kubo-rpc-client, and ipfsd-ctl updates
+      patterns:
+        - "*kubo*"
+        - "ipfsd-ctl"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
 - package-ecosystem: npm
-  directory: "/"
+  directories:
+    - "/"
+    - "/packages/*"
   schedule:
     interval: daily
     time: "10:00"


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
chore: use grouping for dependabot

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Attempting to modify dependabot so that dependencies that should be grouped are.. this aims to prevent a bunch of single dep update PRs that require other deps to be updated at the same time.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
