### PR TITLE
fix: do not connect to bootstrap nodes in browsers

### DIFF
--- a/packages/verified-fetch/src/utils/libp2p-defaults.browser.ts
+++ b/packages/verified-fetch/src/utils/libp2p-defaults.browser.ts
@@ -12,6 +12,7 @@ export function getLibp2pConfig (): Libp2pOptions & Required<Pick<Libp2pOptions,
   libp2pDefaultOptions.start = false
   libp2pDefaultOptions.addresses = { listen: [] }
   libp2pDefaultOptions.transports = [webRTCDirect(), webSockets()]
+  libp2pDefaultOptions.peerDiscovery = [] // Avoid connecting to bootstrap nodes
 
   const services: ServiceFactoryMap<ServiceMap> = {
     dcutr: libp2pDefaultOptions.services.dcutr,


### PR DESCRIPTION
## Description

We don't really need the bootstrap nodes for retrieval. 

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
