### PR TITLE
chore: fix docs and depcheck error

### DIFF
--- a/packages/verified-fetch/.aegir.js
+++ b/packages/verified-fetch/.aegir.js
@@ -1,5 +1,10 @@
 /** @type {import('aegir').PartialOptions} */
 const options = {
+  dependencyCheck: {
+    ignore: [
+      '@multiformats/blake2'
+    ]
+  },
   build: {
     bundlesizeMax: '132KB'
   }

--- a/packages/verified-fetch/README.md
+++ b/packages/verified-fetch/README.md
@@ -235,7 +235,6 @@ If you need to use a different hasher, you can provide a [custom `hasher` functi
 
 ```typescript
 import { createVerifiedFetch } from '@helia/verified-fetch'
-// @ts-expect-error - blake2b256 is not a direct dependency
 import { blake2b256 } from '@multiformats/blake2/blake2b'
 
 const verifiedFetch = await createVerifiedFetch({

--- a/packages/verified-fetch/package.json
+++ b/packages/verified-fetch/package.json
@@ -184,6 +184,7 @@
     "@ipld/car": "^5.3.2",
     "@libp2p/crypto": "^5.0.7",
     "@libp2p/logger": "^5.1.4",
+    "@multiformats/blake2": "^2.0.2",
     "@sgtpooki/file-type": "^1.0.1",
     "@types/sinon": "^17.0.3",
     "aegir": "^45.0.1",

--- a/packages/verified-fetch/src/index.ts
+++ b/packages/verified-fetch/src/index.ts
@@ -204,7 +204,6 @@
  *
  * ```typescript
  * import { createVerifiedFetch } from '@helia/verified-fetch'
- * // @ts-expect-error - blake2b256 is not a direct dependency
  * import { blake2b256 } from '@multiformats/blake2/blake2b'
  *
  * const verifiedFetch = await createVerifiedFetch({


### PR DESCRIPTION
This is one way to resolve the issue mentioned by @2color in https://github.com/ipfs/helia-verified-fetch/pull/156#issuecomment-2515019000

it removes the need to add a //ts-expect-error in the example code generated on the README.md