### PR TITLE
feat: add server timing to responses

### DIFF
--- a/packages/verified-fetch/src/utils/server-timing.ts
+++ b/packages/verified-fetch/src/utils/server-timing.ts
@@ -1,0 +1,37 @@
+export interface ServerTimingSuccess<T> {
+  error: null
+  result: T
+  header: string
+}
+export interface ServerTimingError {
+  result: null
+  error: Error
+  header: string
+}
+export type ServerTimingResult<T> = ServerTimingSuccess<T> | ServerTimingError
+
+export async function serverTiming<T> (
+  name: string,
+  description: string,
+  fn: () => Promise<T>
+): Promise<ServerTimingResult<T>> {
+  const startTime = performance.now()
+
+  try {
+    const result = await fn() // Execute the function
+    const endTime = performance.now()
+
+    const duration = (endTime - startTime).toFixed(1) // Duration in milliseconds
+
+    // Create the Server-Timing header string
+    const header = `${name};dur=${duration};desc="${description}"`
+    return { result, header, error: null }
+  } catch (error: any) {
+    const endTime = performance.now()
+    const duration = (endTime - startTime).toFixed(1)
+
+    // Still return a timing header even on error
+    const header = `${name};dur=${duration};desc="${description}"`
+    return { result: null, error, header } // Pass error with timing info
+  }
+}


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
feat: add server timing to responses

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

This PR adds server timing headers to responses by wrapping all responses returned by `fetch` in a `Response` object that includes the server timing headers.

The headers are generated by wrapping async functions with a `serverTiming` utility function that records the time taken to execute the function, and then adding those headers to an array on the VerifiedFetch class.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

We need to work out exactly what events we need to time, and I'd also like to clean up the `serverTiming` utility function usage so that it's easier to add new timings without having to handle the error and success cases manually for each one.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
