### PR TITLE
fix: limit size of firstChunk

### DIFF
--- a/packages/verified-fetch/src/utils/get-stream-from-async-iterable.ts
+++ b/packages/verified-fetch/src/utils/get-stream-from-async-iterable.ts
@@ -46,6 +46,6 @@ export async function getStreamFromAsyncIterable (iterator: AsyncIterable<Uint8A
 
   return {
     stream,
-    firstChunk
+    firstChunk: firstChunk.slice(0, 8192)
   }
 }

--- a/packages/verified-fetch/test/get-stream-from-async-iterable.spec.ts
+++ b/packages/verified-fetch/test/get-stream-from-async-iterable.spec.ts
@@ -2,6 +2,7 @@ import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import sinon from 'sinon'
 import { getStreamFromAsyncIterable } from '../src/utils/get-stream-from-async-iterable.js'
+import { equals } from 'uint8arrays/equals'
 
 describe('getStreamFromAsyncIterable', () => {
   let onProgressSpy: sinon.SinonSpy
@@ -19,7 +20,7 @@ describe('getStreamFromAsyncIterable', () => {
     const chunks = new TextEncoder().encode('Hello, world!')
     const iterator = (async function * () { yield chunks })()
     const { firstChunk, stream } = await getStreamFromAsyncIterable(iterator, 'test.txt', defaultLogger(), { onProgress: onProgressSpy })
-    expect(firstChunk).to.equal(chunks)
+    expect(equals(firstChunk, chunks)).to.equal(true)
     const reader = stream.getReader()
     const { value } = await reader.read()
     expect(onProgressSpy.callCount).to.equal(1)
@@ -31,7 +32,7 @@ describe('getStreamFromAsyncIterable', () => {
     const chunks = ['Hello,', ' world!'].map((txt) => textEncoder.encode(txt))
     const iterator = (async function * () { yield chunks[0]; yield chunks[1] })()
     const { firstChunk, stream } = await getStreamFromAsyncIterable(iterator, 'test.txt', defaultLogger(), { onProgress: onProgressSpy })
-    expect(firstChunk).to.equal(chunks[0])
+    expect(equals(firstChunk, chunks[0])).to.equal(true)
     const reader = stream.getReader()
     let result = ''
     let chunk
@@ -61,7 +62,7 @@ describe('getStreamFromAsyncIterable', () => {
     }
     const { firstChunk, stream } = await getStreamFromAsyncIterable(iterator, 'test.txt', defaultLogger(), { onProgress: onProgressSpy })
     // @ts-expect-error - actualFirstChunk is not used before set, because the await above.
-    expect(firstChunk).to.equal(actualFirstChunk)
+    expect(equals(firstChunk, actualFirstChunk)).to.equal(true)
     const reader = stream.getReader()
     const result = []
     let chunk

--- a/packages/verified-fetch/test/get-stream-from-async-iterable.spec.ts
+++ b/packages/verified-fetch/test/get-stream-from-async-iterable.spec.ts
@@ -1,8 +1,8 @@
 import { defaultLogger } from '@libp2p/logger'
 import { expect } from 'aegir/chai'
 import sinon from 'sinon'
-import { getStreamFromAsyncIterable } from '../src/utils/get-stream-from-async-iterable.js'
 import { equals } from 'uint8arrays/equals'
+import { getStreamFromAsyncIterable } from '../src/utils/get-stream-from-async-iterable.js'
 
 describe('getStreamFromAsyncIterable', () => {
   let onProgressSpy: sinon.SinonSpy


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

fix: limit size of firstChunk to 8kB

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Addresses an issue brought up by @lidel where the first chunk of content was being read in its entirety, which could lead to memory exhaustion for large files. This PR limits the size of the first chunk to 8kB.

We only use this first chunk for content-type recognition.

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
