### PR TITLE
fix: go bin path

### DIFF
--- a/packages/gateway-conformance/src/conformance.spec.ts
+++ b/packages/gateway-conformance/src/conformance.spec.ts
@@ -25,8 +25,8 @@ function getGatewayConformanceBinaryPath (): string {
   if (process.env.GATEWAY_CONFORMANCE_BINARY != null) {
     return process.env.GATEWAY_CONFORMANCE_BINARY
   }
-  const goPath = process.env.GOPATH ?? join(homedir(), 'go', 'bin')
-  return join(goPath, 'gateway-conformance')
+  const goPath = process.env.GOPATH ?? join(homedir(), 'go')
+  return join(goPath, 'bin', 'gateway-conformance')
 }
 
 function getConformanceTestArgs (name: string, gwcArgs: string[] = [], goTestArgs: string[] = []): string[] {


### PR DESCRIPTION
## Title

Fix the way the go bin path is constructed if GOPATH is set. Make sure we also add `bin` to the path, because binaries live in the `$GOPATH/bin`.

See https://go.dev/wiki/GOPATH