### PR TITLE
fix: etag is path aware

### DIFF
--- a/packages/verified-fetch/src/plugins/types.ts
+++ b/packages/verified-fetch/src/plugins/types.ts
@@ -29,7 +29,7 @@ export interface PluginOptions {
  * - Shared Data: Allows plugins to communicate partial results, discovered data, or interim errors.
  * - Ephemeral: Typically discarded once fetch(...) completes.
  */
-export interface PluginContext {
+export interface PluginContext extends ParsedUrlStringResults {
   readonly cid: CID
   readonly path: string
   readonly resource: string
@@ -47,7 +47,6 @@ export interface PluginContext {
   errors?: PluginError[]
   reqFormat?: RequestFormatShorthand
   pathDetails?: PathWalkerResponse
-  query: ParsedUrlStringResults['query']
   [key: string]: unknown
 }
 


### PR DESCRIPTION

## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

fix: etag is path aware

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Update plugin types & make work with `handleFinaleResponse`, clean up `fetch` impl internals, add get-e-tag test to verify path-awareness.

Fixes #196

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
