### PR TITLE
fix: dir-index-html shorthash links correctly

### DIFF
--- a/packages/verified-fetch/src/utils/dir-index-html.ts
+++ b/packages/verified-fetch/src/utils/dir-index-html.ts
@@ -105,8 +105,7 @@ function getGatewayURLWithoutSubdomain (gatewayURL: string): URL {
     // If the gatewayURL is invalid (ipfs:// or ipns:// or just a CID), use inbrowser.link as a fallback
     currentUrl = new URL('https://inbrowser.link')
   }
-  const newHost = removeIpfsOrIpnsSubdomain(currentUrl.host)
-  currentUrl.host = newHost
+  currentUrl.host = removeIpfsOrIpnsSubdomain(currentUrl.host)
   return currentUrl
 }
 


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
fix: dir-index-html shorthash links correctly

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->
Strips the subdomain for short-hash link clicks. Mimics what dweb.link dir-index-html does.

Fixes https://github.com/ipfs/service-worker-gateway/issues/639
## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
