### PR TITLE
fix: ending path is not assumed to be filename

### DIFF
--- a/packages/interop/src/json.spec.ts
+++ b/packages/interop/src/json.spec.ts
@@ -40,5 +40,18 @@ describe('@helia/verified-fetch - json', () => {
       expect(jsonObj).to.have.property('keywords').to.deep.equal(['uniswap', 'default'])
       expect(jsonObj.tokens).to.be.an('array').of.length(767)
     })
+
+    it('handles hamt-sharded directory with json file', async () => {
+      const resp = await verifiedFetch('ipfs://bafybeibc5sgo2plmjkq2tzmhrn54bk3crhnc23zd2msg4ea7a4pxrkgfna/371', {
+        allowLocal: true,
+        allowInsecure: true
+      })
+      expect(resp).to.be.ok()
+      expect(resp.status).to.equal(200)
+      expect(resp.headers.get('content-type')).to.equal('application/json')
+      const jsonObj = await resp.json()
+      expect(jsonObj).to.be.ok()
+      expect(jsonObj).to.have.property('name').equal('Pudgy Penguin #371')
+    })
   })
 })

--- a/packages/verified-fetch/src/plugins/plugin-handle-dag-pb.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-dag-pb.ts
@@ -52,7 +52,7 @@ export class DagPbPlugin extends BasePlugin {
   }
 
   async handle (context: PluginContext & Required<Pick<PluginContext, 'byteRangeContext' | 'pathDetails'>>): Promise<Response | null> {
-    const { cid, options, withServerTiming = false, pathDetails } = context
+    const { cid, options, withServerTiming = false, pathDetails, query } = context
     const { handleServerTiming, contentTypeParser, helia, getBlockstore } = this.pluginOptions
     const log = this.log
     let resource = context.resource
@@ -155,7 +155,7 @@ export class DagPbPlugin extends BasePlugin {
         redirected
       })
 
-      await handleServerTiming('set-content-type', '', async () => setContentType({ bytes: firstChunk, path, response, contentTypeParser, log }), withServerTiming)
+      await handleServerTiming('set-content-type', '', async () => setContentType({ filename: query.filename, bytes: firstChunk, path, response, contentTypeParser, log }), withServerTiming)
 
       setIpfsRoots(response, ipfsRoots)
 

--- a/packages/verified-fetch/src/plugins/plugin-handle-raw.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-raw.ts
@@ -86,7 +86,7 @@ export class RawPlugin extends BasePlugin {
     // if the user has specified an `Accept` header that corresponds to a raw
     // type, honour that header, so for example they don't request
     // `application/vnd.ipld.raw` but get `application/octet-stream`
-    await setContentType({ bytes: result, path, response, defaultContentType: getOverridenRawContentType({ headers: options?.headers, accept }), contentTypeParser, log })
+    await setContentType({ filename: query.filename, bytes: result, path, response, defaultContentType: getOverridenRawContentType({ headers: options?.headers, accept }), contentTypeParser, log })
 
     return response
   }

--- a/packages/verified-fetch/src/utils/set-content-type.ts
+++ b/packages/verified-fetch/src/utils/set-content-type.ts
@@ -10,15 +10,27 @@ export interface SetContentTypeOptions {
   defaultContentType?: string
   contentTypeParser: ContentTypeParser | undefined
   log: Logger
+
+  /**
+   * This should be set to the `filename` query parameter for the given request.
+   *
+   * @see https://specs.ipfs.tech/http-gateways/path-gateway/#filename-request-query-parameter
+   */
+  filename?: string
 }
 
-export async function setContentType ({ bytes, path, response, contentTypeParser, log, defaultContentType = 'application/octet-stream' }: SetContentTypeOptions): Promise<void> {
+export async function setContentType ({ bytes, path, response, contentTypeParser, log, defaultContentType = 'application/octet-stream', filename: filenameParam }: SetContentTypeOptions): Promise<void> {
   let contentType: string | undefined
 
   if (contentTypeParser != null) {
     try {
-      let fileName = path.split('/').pop()?.trim()
-      fileName = fileName === '' ? undefined : fileName
+      let fileName
+      if (filenameParam == null) {
+        fileName = path.split('/').pop()?.trim()
+        fileName = (fileName === '' || fileName?.split('.').length === 1) ? undefined : fileName
+      } else {
+        fileName = filenameParam
+      }
       const parsed = contentTypeParser(bytes, fileName)
 
       if (isPromise(parsed)) {


### PR DESCRIPTION
- **test: reproduce #228**
- **fix: setContentType does not assume path end is filename**
- **fix: pass filename query param to setContentType**

## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

fix: ending path is not assumed to be filename

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Previously, the `setContentType` function assumed that the ending path of the request was the filename. This is not always the case, as paths may end in some label not reflective of the filename.

Also, we now utilize the `filename` query parameter when setting the content-type, as specified by the [Path Gateway spec](https://specs.ipfs.tech/http-gateways/path-gateway/#filename-request-query-parameter).

Fixes https://github.com/ipfs/helia-verified-fetch/issues/228


## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
