### PR TITLE
fix!: plugins require a unique id

### DIFF
--- a/packages/verified-fetch/src/plugins/plugin-base.ts
+++ b/packages/verified-fetch/src/plugins/plugin-base.ts
@@ -5,18 +5,19 @@ import type { Logger } from '@libp2p/interface'
  * Base class for verified-fetch plugins. This class provides a basic implementation of the `FetchHandlerPlugin`
  * interface.
  *
- * Subclasses should implement the `canHandle` and `handle` methods, and may override the `codes` and `log` properties.
+ * Subclasses should implement the `canHandle` and `handle` methods and should set a unique `id` property.
+ * Subclasses may override the `codes` and `log` properties.
  *
  * If your plugin adds/edits the context supplied in `handle`, you should increment the `context.modified` property.
  */
-export class BasePlugin implements VerifiedFetchPlugin {
+export class BasePlugin implements Omit<VerifiedFetchPlugin, 'id'> {
   readonly codes: number[] = []
   readonly log: Logger
   readonly pluginOptions: PluginOptions
-  readonly loggerName?: string
+  readonly id?: string // should be overridden by subclasses
   constructor (options: PluginOptions) {
     // convert a CamelCase string to a kebab-case string for the logger name of subclasses
-    const loggerName = this.loggerName ?? this.constructor.name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+    const loggerName = this.id ?? this.constructor.name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
     this.log = options.logger.forComponent(loggerName)
     this.pluginOptions = options
   }

--- a/packages/verified-fetch/src/plugins/plugin-base.ts
+++ b/packages/verified-fetch/src/plugins/plugin-base.ts
@@ -13,9 +13,10 @@ export class BasePlugin implements VerifiedFetchPlugin {
   readonly codes: number[] = []
   readonly log: Logger
   readonly pluginOptions: PluginOptions
+  readonly loggerName?: string
   constructor (options: PluginOptions) {
     // convert a CamelCase string to a kebab-case string for the logger name of subclasses
-    const loggerName = this.constructor.name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
+    const loggerName = this.loggerName ?? this.constructor.name.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase()
     this.log = options.logger.forComponent(loggerName)
     this.pluginOptions = options
   }

--- a/packages/verified-fetch/src/plugins/plugin-handle-byte-range-context.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-byte-range-context.ts
@@ -1,12 +1,12 @@
 import { ByteRangeContext } from '../utils/byte-range-context.js'
 import { BasePlugin } from './plugin-base.js'
-import type { PluginContext } from './types.js'
+import type { PluginContext, VerifiedFetchPlugin } from './types.js'
 
 /**
  * This plugin simply adds the ByteRangeContext to the PluginContext.
  */
-export class ByteRangeContextPlugin extends BasePlugin {
-  readonly loggerName = 'byte-range-context-plugin'
+export class ByteRangeContextPlugin extends BasePlugin implements VerifiedFetchPlugin {
+  readonly id = 'byte-range-context-plugin'
 
   /**
    * Return false if the ByteRangeContext has already been set, otherwise return true.

--- a/packages/verified-fetch/src/plugins/plugin-handle-byte-range-context.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-byte-range-context.ts
@@ -6,6 +6,8 @@ import type { PluginContext } from './types.js'
  * This plugin simply adds the ByteRangeContext to the PluginContext.
  */
 export class ByteRangeContextPlugin extends BasePlugin {
+  readonly loggerName = 'byte-range-context-plugin'
+
   /**
    * Return false if the ByteRangeContext has already been set, otherwise return true.
    */

--- a/packages/verified-fetch/src/plugins/plugin-handle-car.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-car.ts
@@ -19,6 +19,7 @@ function getFilename ({ cid, ipfsPath, query }: Pick<PluginContext, 'query' | 'c
  * of the `DAG` referenced by the `CID`.
  */
 export class CarPlugin extends BasePlugin {
+  readonly loggerName = 'car-plugin'
   canHandle (context: PluginContext): boolean {
     this.log('checking if we can handle %c with accept %s', context.cid, context.accept)
     // if (context.pathDetails == null) {

--- a/packages/verified-fetch/src/plugins/plugin-handle-car.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-car.ts
@@ -2,7 +2,7 @@ import { car } from '@helia/car'
 import toBrowserReadableStream from 'it-to-browser-readablestream'
 import { okRangeResponse } from '../utils/responses.js'
 import { BasePlugin } from './plugin-base.js'
-import type { PluginContext } from './types.js'
+import type { PluginContext, VerifiedFetchPlugin } from './types.js'
 
 function getFilename ({ cid, ipfsPath, query }: Pick<PluginContext, 'query' | 'cid' | 'ipfsPath'>): string {
   if (query.filename != null) {
@@ -18,8 +18,9 @@ function getFilename ({ cid, ipfsPath, query }: Pick<PluginContext, 'query' | 'c
  * Accepts a `CID` and returns a `Response` with a body stream that is a CAR
  * of the `DAG` referenced by the `CID`.
  */
-export class CarPlugin extends BasePlugin {
-  readonly loggerName = 'car-plugin'
+export class CarPlugin extends BasePlugin implements VerifiedFetchPlugin {
+  readonly id = 'car-plugin'
+
   canHandle (context: PluginContext): boolean {
     this.log('checking if we can handle %c with accept %s', context.cid, context.accept)
     // if (context.pathDetails == null) {

--- a/packages/verified-fetch/src/plugins/plugin-handle-dag-cbor.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-dag-cbor.ts
@@ -5,14 +5,14 @@ import { setIpfsRoots } from '../utils/response-headers.js'
 import { notAcceptableResponse, okRangeResponse } from '../utils/responses.js'
 import { isObjectNode } from '../utils/walk-path.js'
 import { BasePlugin } from './plugin-base.js'
-import type { PluginContext } from './types.js'
+import type { PluginContext, VerifiedFetchPlugin } from './types.js'
 import type { ObjectNode } from 'ipfs-unixfs-exporter'
 
 /**
  * Handles `dag-cbor` content, including requests with Accept: `application/vnd.ipld.dag-json` and `application/json`.
  */
-export class DagCborPlugin extends BasePlugin {
-  readonly loggerName = 'dag-cbor-plugin'
+export class DagCborPlugin extends BasePlugin implements VerifiedFetchPlugin {
+  readonly id = 'dag-cbor-plugin'
   readonly codes = [ipldDagCbor.code]
 
   canHandle ({ cid, accept, pathDetails, byteRangeContext }: PluginContext): boolean {

--- a/packages/verified-fetch/src/plugins/plugin-handle-dag-cbor.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-dag-cbor.ts
@@ -12,6 +12,7 @@ import type { ObjectNode } from 'ipfs-unixfs-exporter'
  * Handles `dag-cbor` content, including requests with Accept: `application/vnd.ipld.dag-json` and `application/json`.
  */
 export class DagCborPlugin extends BasePlugin {
+  readonly loggerName = 'dag-cbor-plugin'
   readonly codes = [ipldDagCbor.code]
 
   canHandle ({ cid, accept, pathDetails, byteRangeContext }: PluginContext): boolean {

--- a/packages/verified-fetch/src/plugins/plugin-handle-dag-pb.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-dag-pb.ts
@@ -7,14 +7,14 @@ import { setIpfsRoots } from '../utils/response-headers.js'
 import { badGatewayResponse, badRangeResponse, movedPermanentlyResponse, notSupportedResponse, okRangeResponse } from '../utils/responses.js'
 import { setContentType } from '../utils/set-content-type.js'
 import { BasePlugin } from './plugin-base.js'
-import type { PluginContext } from './types.js'
+import type { PluginContext, VerifiedFetchPlugin } from './types.js'
 import type { CIDDetail } from '../index.js'
 
 /**
  * Handles UnixFS and dag-pb content.
  */
-export class DagPbPlugin extends BasePlugin {
-  readonly loggerName = 'dag-pb-plugin'
+export class DagPbPlugin extends BasePlugin implements VerifiedFetchPlugin {
+  readonly id = 'dag-pb-plugin'
   readonly codes = [dagPbCode]
   canHandle ({ cid, accept, pathDetails, byteRangeContext }: PluginContext): boolean {
     this.log('checking if we can handle %c with accept %s', cid, accept)

--- a/packages/verified-fetch/src/plugins/plugin-handle-dag-pb.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-dag-pb.ts
@@ -14,6 +14,7 @@ import type { CIDDetail } from '../index.js'
  * Handles UnixFS and dag-pb content.
  */
 export class DagPbPlugin extends BasePlugin {
+  readonly loggerName = 'dag-pb-plugin'
   readonly codes = [dagPbCode]
   canHandle ({ cid, accept, pathDetails, byteRangeContext }: PluginContext): boolean {
     this.log('checking if we can handle %c with accept %s', cid, accept)

--- a/packages/verified-fetch/src/plugins/plugin-handle-dag-walk.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-dag-walk.ts
@@ -2,7 +2,7 @@ import { code as dagCborCode } from '@ipld/dag-cbor'
 import { code as dagPbCode } from '@ipld/dag-pb'
 import { handlePathWalking } from '../utils/walk-path.js'
 import { BasePlugin } from './plugin-base.js'
-import type { PluginContext } from './types.js'
+import type { PluginContext, VerifiedFetchPlugin } from './types.js'
 
 /**
  * This plugin should almost always run first because it's going to handle path walking if needed, and will only say it can handle
@@ -10,8 +10,8 @@ import type { PluginContext } from './types.js'
  *
  * Once this plugin has run, the PluginContext will be updated and then this plugin will return false for canHandle, so it won't run again.
  */
-export class DagWalkPlugin extends BasePlugin {
-  readonly loggerName = 'dag-walk-plugin'
+export class DagWalkPlugin extends BasePlugin implements VerifiedFetchPlugin {
+  readonly id = 'dag-walk-plugin'
   /**
    * Return false if the path has already been walked, otherwise return true if the CID is encoded with a codec that supports pathing.
    */

--- a/packages/verified-fetch/src/plugins/plugin-handle-dag-walk.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-dag-walk.ts
@@ -11,6 +11,7 @@ import type { PluginContext } from './types.js'
  * Once this plugin has run, the PluginContext will be updated and then this plugin will return false for canHandle, so it won't run again.
  */
 export class DagWalkPlugin extends BasePlugin {
+  readonly loggerName = 'dag-walk-plugin'
   /**
    * Return false if the path has already been walked, otherwise return true if the CID is encoded with a codec that supports pathing.
    */

--- a/packages/verified-fetch/src/plugins/plugin-handle-dir-index-html.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-dir-index-html.ts
@@ -24,6 +24,7 @@ async function getAssetHash (directoryEntries: UnixFSEntry[]): Promise<string> {
 }
 
 export class DirIndexHtmlPlugin extends BasePlugin {
+  readonly loggerName = 'dir-index-html-plugin'
   readonly codes = [dagPbCode]
   canHandle (context: PluginContext): boolean {
     const { cid, pathDetails, directoryEntries } = context

--- a/packages/verified-fetch/src/plugins/plugin-handle-dir-index-html.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-dir-index-html.ts
@@ -6,7 +6,7 @@ import { getETag } from '../utils/get-e-tag.js'
 import { getIpfsRoots } from '../utils/response-headers.js'
 import { okRangeResponse } from '../utils/responses.js'
 import { BasePlugin } from './plugin-base.js'
-import type { PluginContext, VerifiedFetchPluginFactory } from './types.js'
+import type { PluginContext, VerifiedFetchPlugin, VerifiedFetchPluginFactory } from './types.js'
 import type { UnixFSEntry } from 'ipfs-unixfs-exporter'
 
 /**
@@ -23,8 +23,8 @@ async function getAssetHash (directoryEntries: UnixFSEntry[]): Promise<string> {
   return base32.encode(hashBytes)
 }
 
-export class DirIndexHtmlPlugin extends BasePlugin {
-  readonly loggerName = 'dir-index-html-plugin'
+export class DirIndexHtmlPlugin extends BasePlugin implements VerifiedFetchPlugin {
+  readonly id = 'dir-index-html-plugin'
   readonly codes = [dagPbCode]
   canHandle (context: PluginContext): boolean {
     const { cid, pathDetails, directoryEntries } = context

--- a/packages/verified-fetch/src/plugins/plugin-handle-ipns-record.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-ipns-record.ts
@@ -7,15 +7,15 @@ import { getPeerIdFromString } from '../utils/get-peer-id-from-string.js'
 import { badRequestResponse, okRangeResponse } from '../utils/responses.js'
 import { PluginFatalError } from './errors.js'
 import { BasePlugin } from './plugin-base.js'
-import type { PluginContext } from './types.js'
+import type { PluginContext, VerifiedFetchPlugin } from './types.js'
 import type { PeerId } from '@libp2p/interface'
 
 /**
  * Accepts an `ipns://...`, `https?://<ipnsname>.ipns.<domain>`, or `https?://<domain>/ipns/...` URL as a string and
  * returns a `Response` containing a raw IPNS record.
  */
-export class IpnsRecordPlugin extends BasePlugin {
-  readonly loggerName = 'ipns-record-plugin'
+export class IpnsRecordPlugin extends BasePlugin implements VerifiedFetchPlugin {
+  readonly id = 'ipns-record-plugin'
   readonly codes = []
   canHandle ({ cid, accept, query, byteRangeContext }: PluginContext): boolean {
     this.log('checking if we can handle %c with accept %s', cid, accept)

--- a/packages/verified-fetch/src/plugins/plugin-handle-ipns-record.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-ipns-record.ts
@@ -15,6 +15,7 @@ import type { PeerId } from '@libp2p/interface'
  * returns a `Response` containing a raw IPNS record.
  */
 export class IpnsRecordPlugin extends BasePlugin {
+  readonly loggerName = 'ipns-record-plugin'
   readonly codes = []
   canHandle ({ cid, accept, query, byteRangeContext }: PluginContext): boolean {
     this.log('checking if we can handle %c with accept %s', cid, accept)

--- a/packages/verified-fetch/src/plugins/plugin-handle-json.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-json.ts
@@ -9,6 +9,7 @@ import type { PluginContext } from './types.js'
  * Handles `dag-json` content, including requests with Accept: `application/vnd.ipld.dag-cbor` and `application/cbor`.
  */
 export class JsonPlugin extends BasePlugin {
+  readonly loggerName = 'json-plugin'
   readonly codes = [ipldDagJson.code, jsonCode]
   canHandle ({ cid, accept, byteRangeContext }: PluginContext): boolean {
     this.log('checking if we can handle %c with accept %s', cid, accept)

--- a/packages/verified-fetch/src/plugins/plugin-handle-json.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-json.ts
@@ -3,13 +3,13 @@ import * as ipldDagJson from '@ipld/dag-json'
 import { code as jsonCode } from 'multiformats/codecs/json'
 import { notAcceptableResponse, okRangeResponse } from '../utils/responses.js'
 import { BasePlugin } from './plugin-base.js'
-import type { PluginContext } from './types.js'
+import type { PluginContext, VerifiedFetchPlugin } from './types.js'
 
 /**
  * Handles `dag-json` content, including requests with Accept: `application/vnd.ipld.dag-cbor` and `application/cbor`.
  */
-export class JsonPlugin extends BasePlugin {
-  readonly loggerName = 'json-plugin'
+export class JsonPlugin extends BasePlugin implements VerifiedFetchPlugin {
+  readonly id = 'json-plugin'
   readonly codes = [ipldDagJson.code, jsonCode]
   canHandle ({ cid, accept, byteRangeContext }: PluginContext): boolean {
     this.log('checking if we can handle %c with accept %s', cid, accept)

--- a/packages/verified-fetch/src/plugins/plugin-handle-raw.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-raw.ts
@@ -4,7 +4,7 @@ import { notFoundResponse, okRangeResponse } from '../utils/responses.js'
 import { setContentType } from '../utils/set-content-type.js'
 import { PluginFatalError } from './errors.js'
 import { BasePlugin } from './plugin-base.js'
-import type { PluginContext } from './types.js'
+import type { PluginContext, VerifiedFetchPlugin } from './types.js'
 
 /**
  * These are Accept header values that will cause content type sniffing to be
@@ -42,8 +42,8 @@ function getOverriddenRawContentType ({ headers, accept }: { headers?: HeadersIn
   }
 }
 
-export class RawPlugin extends BasePlugin {
-  readonly loggerName = 'raw-plugin'
+export class RawPlugin extends BasePlugin implements VerifiedFetchPlugin {
+  readonly id = 'raw-plugin'
   codes: number[] = [rawCode, identity.code]
 
   canHandle ({ cid, accept, query, byteRangeContext }: PluginContext): boolean {

--- a/packages/verified-fetch/src/plugins/plugin-handle-raw.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-raw.ts
@@ -43,6 +43,7 @@ function getOverriddenRawContentType ({ headers, accept }: { headers?: HeadersIn
 }
 
 export class RawPlugin extends BasePlugin {
+  readonly loggerName = 'raw-plugin'
   codes: number[] = [rawCode, identity.code]
 
   canHandle ({ cid, accept, query, byteRangeContext }: PluginContext): boolean {

--- a/packages/verified-fetch/src/plugins/plugin-handle-tar.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-tar.ts
@@ -12,6 +12,7 @@ import type { PluginContext } from './types.js'
  * directory structure referenced by the `CID`.
  */
 export class TarPlugin extends BasePlugin {
+  readonly loggerName = 'tar-plugin'
   readonly codes = []
   canHandle ({ cid, accept, query, byteRangeContext }: PluginContext): boolean {
     this.log('checking if we can handle %c with accept %s', cid, accept)

--- a/packages/verified-fetch/src/plugins/plugin-handle-tar.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-tar.ts
@@ -5,14 +5,14 @@ import { getETag } from '../utils/get-e-tag.js'
 import { tarStream } from '../utils/get-tar-stream.js'
 import { notAcceptableResponse, okRangeResponse } from '../utils/responses.js'
 import { BasePlugin } from './plugin-base.js'
-import type { PluginContext } from './types.js'
+import type { PluginContext, VerifiedFetchPlugin } from './types.js'
 
 /**
  * Accepts a UnixFS `CID` and returns a `.tar` file containing the file or
  * directory structure referenced by the `CID`.
  */
-export class TarPlugin extends BasePlugin {
-  readonly loggerName = 'tar-plugin'
+export class TarPlugin extends BasePlugin implements VerifiedFetchPlugin {
+  readonly id = 'tar-plugin'
   readonly codes = []
   canHandle ({ cid, accept, query, byteRangeContext }: PluginContext): boolean {
     this.log('checking if we can handle %c with accept %s', cid, accept)

--- a/packages/verified-fetch/src/plugins/types.ts
+++ b/packages/verified-fetch/src/plugins/types.ts
@@ -60,6 +60,7 @@ export interface PluginContext extends ParsedUrlStringResults {
 }
 
 export interface VerifiedFetchPlugin {
+  readonly id: string
   readonly codes: number[]
   readonly log: Logger
   canHandle (context: PluginContext): boolean

--- a/packages/verified-fetch/test/fixtures/get-custom-plugin-factory.ts
+++ b/packages/verified-fetch/test/fixtures/get-custom-plugin-factory.ts
@@ -4,6 +4,7 @@ import type { PluginContext, PluginOptions } from '../../src/plugins/types.js'
 export interface PluginFixtureOptions {
   codes?: number[]
   constructorName?: string
+  id?: string
   canHandle?(context: PluginContext): boolean
   handle?(context: PluginContext): Promise<Response | null>
 }
@@ -13,6 +14,7 @@ export const getCustomPluginFactory = (options: PluginFixtureOptions) => {
 
   const classes = {
     [className]: class extends BasePlugin {
+      id = options.id ?? options.constructorName?.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase() ?? 'custom-plugin'
       codes = options.codes ?? []
 
       canHandle (context: PluginContext): boolean {


### PR DESCRIPTION
- **fix: add id for logging and plugin recognition**
- **fix: use id for plugin identification**

## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

fix!: plugins require a unique id

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Previously when debugging, lognames were not clear because they were based off the class name, which is minified in production builds, resulting in confusing log messages.

Now, we require plugins to have a unique id, and use it for logging and filtering and plugin overrides by consumers.

Fixes #243

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
