### PR TITLE
fix: svg content type recognition

### DIFF
--- a/packages/verified-fetch/src/utils/content-type-parser.ts
+++ b/packages/verified-fetch/src/utils/content-type-parser.ts
@@ -40,6 +40,9 @@ export async function contentTypeParser (bytes: Uint8Array, fileName?: string): 
   const detectedType = (await fileTypeFromBuffer(bytes))?.mime
   if (detectedType != null) {
     log('detectedType: %s', detectedType)
+    if (detectedType === 'application/xml' && fileName?.toLowerCase().endsWith('.svg')) {
+      return 'image/svg+xml'
+    }
     return detectedType
   }
   log('no detectedType')


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->
fix: svg content type recognition

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->
filetypeFromBuffer was returning "application/xml" for some svg files.

Related: https://github.com/ipfs/service-worker-gateway/issues/823
Related: https://github.com/ipfs/service-worker-gateway/pull/832
Fixes https://github.com/ipfs/helia-verified-fetch/issues/268

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
