### PR TITLE
fix: IPIP-0524 restrict content type conversion

### DIFF
--- a/packages/verified-fetch/src/plugins/plugin-handle-raw.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-raw.ts
@@ -26,9 +26,12 @@ export class RawPlugin extends BasePlugin {
     this.log.trace('fetching %c%s', terminalElement.cid, url.pathname)
     const block = await toBuffer(blockstore.get(terminalElement.cid, context))
 
+    const contentType = accept
+      .find(value => value.contentType.mediaType === MEDIA_TYPE_RAW || value.contentType.mediaType === MEDIA_TYPE_OCTET_STREAM)?.contentType.mediaType ?? MEDIA_TYPE_RAW
+
     const headers = {
       'content-length': `${block.byteLength}`,
-      'content-type': accept.some(value => value.contentType.mediaType === MEDIA_TYPE_RAW) ? MEDIA_TYPE_RAW : MEDIA_TYPE_OCTET_STREAM,
+      'content-type': contentType,
       'content-disposition': `${url.searchParams.get('download') === 'false' ? 'inline' : 'attachment'}; ${
         getContentDispositionFilename(url.searchParams.get('filename') ?? `${terminalElement.cid}.raw`)
       }`,

--- a/packages/verified-fetch/src/utils/content-types.ts
+++ b/packages/verified-fetch/src/utils/content-types.ts
@@ -29,7 +29,7 @@ export const CONTENT_TYPE_OCTET_STREAM: ContentType = {
 
 export const CONTENT_TYPE_DAG_CBOR: ContentType = {
   mediaType: MEDIA_TYPE_DAG_CBOR,
-  codecs: [dagCborCode, CODEC_CBOR, dagJsonCode, jsonCode, dagPbCode, rawCode],
+  codecs: [dagCborCode, rawCode, dagPbCode],
   immutable: true,
   extension: '.cbor',
   etag: '.dag-cbor',
@@ -38,7 +38,7 @@ export const CONTENT_TYPE_DAG_CBOR: ContentType = {
 
 export const CONTENT_TYPE_CBOR: ContentType = {
   mediaType: MEDIA_TYPE_CBOR,
-  codecs: [CODEC_CBOR, dagCborCode, dagJsonCode, jsonCode, dagPbCode, rawCode],
+  codecs: [CODEC_CBOR, dagCborCode, rawCode, dagPbCode],
   immutable: true,
   extension: '.cbor',
   etag: '.cbor',
@@ -47,7 +47,7 @@ export const CONTENT_TYPE_CBOR: ContentType = {
 
 export const CONTENT_TYPE_DAG_JSON: ContentType = {
   mediaType: MEDIA_TYPE_DAG_JSON,
-  codecs: [dagJsonCode, jsonCode, dagCborCode, CODEC_CBOR, dagPbCode, rawCode],
+  codecs: [dagJsonCode, rawCode, dagPbCode],
   immutable: true,
   extension: '.json',
   etag: '.dag-json',
@@ -56,7 +56,7 @@ export const CONTENT_TYPE_DAG_JSON: ContentType = {
 
 export const CONTENT_TYPE_JSON: ContentType = {
   mediaType: MEDIA_TYPE_JSON,
-  codecs: [jsonCode, dagJsonCode, dagCborCode, CODEC_CBOR, dagPbCode, rawCode],
+  codecs: [jsonCode, dagJsonCode, rawCode, dagPbCode],
   immutable: true,
   extension: '.json',
   etag: '.json',

--- a/packages/verified-fetch/test/accept-header.spec.ts
+++ b/packages/verified-fetch/test/accept-header.spec.ts
@@ -2,7 +2,6 @@ import { dagCbor } from '@helia/dag-cbor'
 import { dagJson } from '@helia/dag-json'
 import { ipns } from '@helia/ipns'
 import * as ipldDagCbor from '@ipld/dag-cbor'
-import * as ipldDagJson from '@ipld/dag-json'
 import { stop } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
 import * as cborg from 'cborg'
@@ -133,7 +132,7 @@ describe('accept header', () => {
     expect(resp.status).to.equal(406)
   })
 
-  it('should transform DAG-CBOR to JSON', async () => {
+  it('should not transform DAG-CBOR to JSON', async () => {
     const obj = {
       hello: 'world'
     }
@@ -145,10 +144,7 @@ describe('accept header', () => {
         accept: 'application/json'
       }
     })
-    expect(resp.headers.get('content-type')).to.equal('application/json')
-
-    const output = ipldDagJson.decode(new Uint8Array(await resp.arrayBuffer()))
-    expect(output).to.deep.equal(obj)
+    expect(resp.status).to.equal(406)
   })
 
   it('should not transform DAG-JSON to DAG-CBOR', async () => {
@@ -166,7 +162,7 @@ describe('accept header', () => {
     expect(resp.status).to.equal(406)
   })
 
-  it('should not transform block when requesting CBOR', async () => {
+  it('should not transform DAG-JSON to CBOR', async () => {
     const obj = {
       hello: 'world'
     }
@@ -178,9 +174,7 @@ describe('accept header', () => {
         accept: 'application/cbor'
       }
     })
-    expect(resp.headers.get('content-type')).to.equal('application/cbor')
-
-    expect(new Uint8Array(await resp.arrayBuffer())).to.equalBytes(ipldDagJson.encode(obj))
+    expect(resp.status).to.equal(406)
   })
 
   it('should return 406 Not Acceptable if the accept header cannot be adhered to', async () => {
@@ -219,16 +213,16 @@ describe('accept header', () => {
     const obj = {
       hello: 'world'
     }
-    const c = dagCbor(helia)
-    const cid = await c.add(obj)
+    const j = dagJson(helia)
+    const cid = await j.add(obj)
 
     const resp = await verifiedFetch.fetch(cid, {
       headers: {
-        accept: '*/json, application/vnd.ipld.raw'
+        accept: '*/vnd.ipld.raw, application/vnd.ipld.dag-json'
       }
     })
     expect(resp.status).to.equal(200)
-    expect(resp.headers.get('content-type')).to.equal('application/json')
+    expect(resp.headers.get('content-type')).to.equal('application/vnd.ipld.raw')
   })
 
   it('should support subtype wildcards', async () => {
@@ -251,8 +245,8 @@ describe('accept header', () => {
     const obj = {
       hello: 'world'
     }
-    const c = dagCbor(helia)
-    const cid = await c.add(obj)
+    const j = dagJson(helia)
+    const cid = await j.add(obj)
 
     const resp = await verifiedFetch.fetch(cid, {
       headers: {
@@ -260,7 +254,7 @@ describe('accept header', () => {
         // application/octet-stream has a higher weighting so it should win
         accept: [
           'application/json;q=0.1',
-          'application/application/vnd.ipld.raw;q=0.5',
+          'application/vnd.ipld.raw;q=0.5',
           'application/octet-stream;q=0.8'
         ].join(', ')
       }

--- a/packages/verified-fetch/test/cbor.spec.ts
+++ b/packages/verified-fetch/test/cbor.spec.ts
@@ -1,12 +1,12 @@
-import * as dagCbor from '@ipld/dag-cbor'
-import * as dagJson from '@ipld/dag-json'
 import { stop } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
 import * as cbor from 'cborg'
 import { CID } from 'multiformats'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { CODEC_CBOR } from '../src/constants.ts'
+import { MEDIA_TYPE_OCTET_STREAM, MEDIA_TYPE_RAW } from '../src/index.ts'
 import { VerifiedFetch } from '../src/verified-fetch.ts'
+import { CBOR_TRANSLATIONS } from './fixtures/codecs.ts'
 import { createHelia } from './fixtures/create-offline-helia.js'
 import type { Helia } from 'helia'
 
@@ -51,159 +51,41 @@ describe('cbor', () => {
     expect(decoded).to.deep.equal(obj)
   })
 
-  it('can download CBOR blocks as application/octet-stream', async () => {
-    const obj = {
-      hello: 'world'
-    }
-    const buf = cbor.encode(obj)
-    const digest = await sha256.digest(buf)
-    const cid = CID.createV1(CODEC_CBOR, digest)
+  for (const translation of CBOR_TRANSLATIONS) {
+    // eslint-disable-next-line no-loop-func
+    it(`${translation.ok ? 'can' : 'can not'} download ${translation.input.name} blocks as ${translation.output.name}`, async () => {
+      const buf = translation.input.encoded()
+      const digest = await sha256.digest(buf)
+      const cid = CID.createV1(translation.input.code, digest)
 
-    await helia.blockstore.put(cid, buf)
+      await helia.blockstore.put(cid, buf)
 
-    const res = await verifiedFetch.fetch(`/ipfs/${cid}`, {
-      headers: {
-        accept: 'application/octet-stream'
+      const res = await verifiedFetch.fetch(`/ipfs/${cid}`, {
+        headers: {
+          accept: translation.output.mediaType
+        }
+      })
+
+      if (translation.ok) {
+        expect(res.ok).to.be.true()
+        expect(res.headers.get('content-type')).to.equal(translation.output.mediaType)
+        expect(res.headers.get('cache-control')).to.equal('public, max-age=29030400, immutable')
+
+        const body = await res.arrayBuffer()
+        translation.input.decode(new Uint8Array(body))
+      } else {
+        expect(res.status).to.equal(406)
+
+        expect(res.status).to.equal(406)
+
+        const acceptable = (await res.json()).acceptable
+
+        expect(acceptable).to.include(translation.input.mediaType)
+        expect(acceptable).to.include(MEDIA_TYPE_RAW)
+        expect(acceptable).to.include(MEDIA_TYPE_OCTET_STREAM)
+
+        expect(acceptable).to.not.include(translation.output.mediaType)
       }
     })
-    expect(res.ok).to.be.true()
-    expect(res.headers.get('content-type')).to.equal('application/octet-stream')
-    expect(res.headers.get('cache-control')).to.equal('public, max-age=29030400, immutable')
-
-    const body = await res.arrayBuffer()
-    const decoded = cbor.decode(new Uint8Array(body))
-
-    expect(decoded).to.deep.equal(obj)
-  })
-
-  it('can download CBOR blocks as raw', async () => {
-    const obj = {
-      hello: 'world'
-    }
-    const buf = cbor.encode(obj)
-    const digest = await sha256.digest(buf)
-    const cid = CID.createV1(CODEC_CBOR, digest)
-
-    await helia.blockstore.put(cid, buf)
-
-    const res = await verifiedFetch.fetch(`/ipfs/${cid}`, {
-      headers: {
-        accept: 'application/vnd.ipld.raw'
-      }
-    })
-    expect(res.ok).to.be.true()
-    expect(res.headers.get('content-type')).to.equal('application/vnd.ipld.raw')
-    expect(res.headers.get('cache-control')).to.equal('public, max-age=29030400, immutable')
-
-    const body = await res.arrayBuffer()
-    const decoded = cbor.decode(new Uint8Array(body))
-
-    expect(decoded).to.deep.equal(obj)
-  })
-
-  it('can download CBOR blocks as CBOR', async () => {
-    const obj = {
-      hello: 'world'
-    }
-    const buf = cbor.encode(obj)
-    const digest = await sha256.digest(buf)
-    const cid = CID.createV1(CODEC_CBOR, digest)
-
-    await helia.blockstore.put(cid, buf)
-
-    const res = await verifiedFetch.fetch(`/ipfs/${cid}`, {
-      headers: {
-        accept: 'application/cbor'
-      }
-    })
-    expect(res.ok).to.be.true()
-    expect(res.headers.get('content-type')).to.equal('application/cbor')
-    expect(res.headers.get('cache-control')).to.equal('public, max-age=29030400, immutable')
-
-    const body = await res.arrayBuffer()
-    const decoded = cbor.decode(new Uint8Array(body))
-
-    expect(decoded).to.deep.equal(obj)
-  })
-
-  it('should not transform block when requesting JSON', async () => {
-    const obj = {
-      hello: 'world'
-    }
-    const buf = cbor.encode(obj)
-    const digest = await sha256.digest(buf)
-    const cid = CID.createV1(CODEC_CBOR, digest)
-
-    await helia.blockstore.put(cid, buf)
-
-    const res = await verifiedFetch.fetch(`/ipfs/${cid}`, {
-      headers: {
-        accept: 'application/json'
-      }
-    })
-    expect(res.ok).to.be.true()
-    expect(res.headers.get('content-type')).to.equal('application/json')
-    expect(res.headers.get('cache-control')).to.equal('public, max-age=29030400, immutable')
-
-    expect(new Uint8Array(await res.arrayBuffer())).to.equalBytes(buf)
-  })
-
-  it('can download CBOR blocks as DAG-CBOR', async () => {
-    const obj = {
-      hello: 'world',
-      link: CID.parse('bafkqaddimvwgy3zao5xxe3debi')
-    }
-    const buf = dagCbor.encode(obj)
-    const digest = await sha256.digest(buf)
-    const cid = CID.createV1(CODEC_CBOR, digest)
-
-    await helia.blockstore.put(cid, buf)
-
-    const res = await verifiedFetch.fetch(`/ipfs/${cid}`, {
-      headers: {
-        accept: 'application/vnd.ipld.dag-cbor'
-      }
-    })
-    expect(res.ok).to.be.true()
-    expect(res.headers.get('content-type')).to.equal('application/vnd.ipld.dag-cbor')
-    expect(res.headers.get('cache-control')).to.equal('public, max-age=29030400, immutable')
-
-    const body = await res.arrayBuffer()
-    const decoded = dagCbor.decode(new Uint8Array(body))
-
-    expect(decoded).to.deep.equal({
-      hello: 'world',
-      link: CID.parse('bafkqaddimvwgy3zao5xxe3debi')
-    })
-  })
-
-  it('can download CBOR blocks as DAG-JSON', async () => {
-    const obj = {
-      hello: 'world',
-      link: {
-        '/': 'bafkqaddimvwgy3zao5xxe3debi'
-      }
-    }
-    const buf = cbor.encode(obj)
-    const digest = await sha256.digest(buf)
-    const cid = CID.createV1(CODEC_CBOR, digest)
-
-    await helia.blockstore.put(cid, buf)
-
-    const res = await verifiedFetch.fetch(`/ipfs/${cid}`, {
-      headers: {
-        accept: 'application/vnd.ipld.dag-json'
-      }
-    })
-    expect(res.ok).to.be.true()
-    expect(res.headers.get('content-type')).to.equal('application/vnd.ipld.dag-json')
-    expect(res.headers.get('cache-control')).to.equal('public, max-age=29030400, immutable')
-
-    const body = await res.arrayBuffer()
-    const decoded = dagJson.decode(new Uint8Array(body))
-    expect(decoded).to.deep.equal({
-      hello: 'world',
-      link: CID.parse('bafkqaddimvwgy3zao5xxe3debi')
-    })
-  })
+  }
 })

--- a/packages/verified-fetch/test/dag-json.spec.ts
+++ b/packages/verified-fetch/test/dag-json.spec.ts
@@ -1,47 +1,13 @@
-import * as dagCbor from '@ipld/dag-cbor'
 import * as dagJson from '@ipld/dag-json'
 import { stop } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
 import { CID } from 'multiformats'
 import { sha256 } from 'multiformats/hashes/sha2'
-import { MEDIA_TYPE_DAG_CBOR } from '../src/index.ts'
-import { CONTENT_TYPE_CBOR, CONTENT_TYPE_DAG_JSON, CONTENT_TYPE_JSON, CONTENT_TYPE_RAW } from '../src/utils/content-types.ts'
+import { MEDIA_TYPE_DAG_JSON, MEDIA_TYPE_OCTET_STREAM, MEDIA_TYPE_RAW } from '../src/utils/content-types.ts'
 import { VerifiedFetch } from '../src/verified-fetch.ts'
+import { DAG_JSON_TRANSLATIONS } from './fixtures/codecs.ts'
 import { createHelia } from './fixtures/create-offline-helia.js'
-import type { ContentType } from '../src/index.ts'
 import type { Helia } from 'helia'
-
-interface Fixture {
-  contentType: ContentType
-  verify (obj: any, cid: CID, block: Uint8Array, res: Response): Promise<void>
-}
-
-const fixtures: Fixture[] = [{
-  contentType: CONTENT_TYPE_DAG_JSON,
-  async verify (obj, cid, block, res) {
-    const body = await res.arrayBuffer()
-    const decoded = dagJson.decode(new Uint8Array(body))
-    expect(decoded).to.deep.equal(obj)
-  }
-}, {
-  contentType: CONTENT_TYPE_JSON,
-  async verify (obj, cid, block, res) {
-    const body = await res.arrayBuffer()
-    expect(new Uint8Array(body)).to.equalBytes(block)
-  }
-}, {
-  contentType: CONTENT_TYPE_CBOR,
-  async verify (obj, cid, block, res) {
-    const body = await res.arrayBuffer()
-    expect(new Uint8Array(body)).to.equalBytes(block)
-  }
-}, {
-  contentType: CONTENT_TYPE_RAW,
-  async verify (obj, cid, block, res) {
-    const body = await res.arrayBuffer()
-    expect(new Uint8Array(body)).to.equalBytes(dagJson.encode(obj))
-  }
-}]
 
 describe('dag-json', () => {
   let helia: Helia
@@ -61,53 +27,62 @@ describe('dag-json', () => {
       hello: 'world',
       link: CID.parse('bafkqaddimvwgy3zao5xxe3debi')
     }
-    const buf = dagCbor.encode(obj)
+    const buf = dagJson.encode(obj)
     const digest = await sha256.digest(buf)
-    const cid = CID.createV1(dagCbor.code, digest)
+    const cid = CID.createV1(dagJson.code, digest)
 
     await helia.blockstore.put(cid, buf)
 
     const res = await verifiedFetch.fetch(`/ipfs/${cid}`)
     expect(res.ok).to.be.true()
-    expect(res.headers.get('content-type')).to.equal(MEDIA_TYPE_DAG_CBOR)
+    expect(res.headers.get('content-type')).to.equal(MEDIA_TYPE_DAG_JSON)
     expect(res.headers.get('cache-control')).to.equal('public, max-age=29030400, immutable')
 
     const body = await res.arrayBuffer()
-    const decoded = dagCbor.decode(new Uint8Array(body))
+    const decoded = dagJson.decode(new Uint8Array(body))
 
     expect(decoded).to.deep.equal(obj)
   })
 
-  for (const fixture of fixtures) {
+  for (const translation of DAG_JSON_TRANSLATIONS) {
     // eslint-disable-next-line no-loop-func
-    it(`should download DAG-JSON blocks as ${fixture.contentType.mediaType}`, async () => {
-      const obj = {
-        hello: 'world',
-        link: CID.parse('bafkqaddimvwgy3zao5xxe3debi')
-      }
-      const block = dagJson.encode(obj)
-      const digest = await sha256.digest(block)
-      const cid = CID.createV1(dagJson.code, digest)
+    it(`${translation.ok ? 'can' : 'can not'} download ${translation.input.name} blocks as ${translation.output.name}`, async () => {
+      const buf = translation.input.encoded()
+      const digest = await sha256.digest(buf)
+      const cid = CID.createV1(translation.input.code, digest)
 
-      await helia.blockstore.put(cid, block)
+      await helia.blockstore.put(cid, buf)
 
       const res = await verifiedFetch.fetch(`/ipfs/${cid}`, {
         headers: {
-          accept: fixture.contentType.mediaType
+          accept: translation.output.mediaType
         }
       })
 
-      expect(res.ok).to.be.true()
-      expect(res.headers.get('content-type')).to.equal(fixture.contentType.mediaType)
-      expect(res.headers.get('etag')).to.equal(`"${cid}${fixture.contentType.etag}"`)
-      expect(res.headers.get('x-content-type-options')).to.equal('nosniff')
-      expect(res.headers.get('cache-control')).to.equal('public, max-age=29030400, immutable')
+      if (translation.ok) {
+        expect(res.ok).to.be.true()
+        expect(res.headers.get('content-type')).to.equal(translation.output.mediaType)
+        expect(res.headers.get('cache-control')).to.equal('public, max-age=29030400, immutable')
 
-      await fixture.verify(obj, cid, block, res)
+        const body = await res.arrayBuffer()
+        translation.input.decode(new Uint8Array(body))
+      } else {
+        expect(res.status).to.equal(406)
+
+        expect(res.status).to.equal(406)
+
+        const acceptable = (await res.json()).acceptable
+
+        expect(acceptable).to.include(translation.input.mediaType)
+        expect(acceptable).to.include(MEDIA_TYPE_RAW)
+        expect(acceptable).to.include(MEDIA_TYPE_OCTET_STREAM)
+
+        expect(acceptable).to.not.include(translation.output.mediaType)
+      }
     })
   }
 
-  it('should not support fetching a raw block as DAG-CBOR', async () => {
+  it.skip('should 501 when there is a path remainder', async () => {
     const obj = {
       hello: 'world',
       link: CID.parse('bafkqaddimvwgy3zao5xxe3debi')
@@ -115,24 +90,6 @@ describe('dag-json', () => {
     const block = dagJson.encode(obj)
     const digest = await sha256.digest(block)
     const cid = CID.createV1(dagJson.code, digest)
-    await helia.blockstore.put(cid, block)
-
-    const res = await verifiedFetch.fetch(`ipfs://${cid}`, {
-      headers: {
-        accept: MEDIA_TYPE_DAG_CBOR
-      }
-    })
-    expect(res.status).to.equal(406)
-  })
-
-  it.skip('should 501 when there is a path remainder', async () => {
-    const obj = {
-      hello: 'world',
-      link: CID.parse('bafkqaddimvwgy3zao5xxe3debi')
-    }
-    const block = dagCbor.encode(obj)
-    const digest = await sha256.digest(block)
-    const cid = CID.createV1(dagCbor.code, digest)
 
     await helia.blockstore.put(cid, block)
 

--- a/packages/verified-fetch/test/fixtures/codecs.ts
+++ b/packages/verified-fetch/test/fixtures/codecs.ts
@@ -1,0 +1,210 @@
+import * as dagCbor from '@ipld/dag-cbor'
+import * as dagJson from '@ipld/dag-json'
+import { expect } from 'aegir/chai'
+import { CID } from 'multiformats/cid'
+import * as json from 'multiformats/codecs/json'
+import * as raw from 'multiformats/codecs/raw'
+import { CODEC_CBOR } from '../../src/constants.ts'
+import { CONTENT_TYPE_CBOR, CONTENT_TYPE_DAG_CBOR, CONTENT_TYPE_DAG_JSON, CONTENT_TYPE_JSON, CONTENT_TYPE_OCTET_STREAM, CONTENT_TYPE_RAW } from '../../src/utils/content-types.ts'
+
+export interface Codec {
+  name: string
+  code: number
+  mediaType: string,
+  encoded(): Uint8Array
+  decode(buf: Uint8Array): void
+}
+
+export interface CodecTranslation {
+  ok: boolean
+  input: Codec
+  output: Codec
+}
+
+const fixtureWithCID = {
+  hello: 'world',
+  link: CID.parse('bafkqaddimvwgy3zao5xxe3debi')
+}
+
+const fixtureWithoutCID = {
+  hello: 'world',
+  link: {
+    '/': 'bafkqaddimvwgy3zao5xxe3debi'
+  }
+}
+
+export const RAW: Codec = {
+  name: 'RAW',
+  code: raw.code,
+  mediaType: CONTENT_TYPE_RAW.mediaType,
+  encoded () {
+    return json.encode(fixtureWithoutCID)
+  },
+  decode (buf) {
+    expect(json.decode(buf)).to.deep.equal(fixtureWithoutCID)
+  }
+}
+
+export const OCTET_STREAM: Codec = {
+  name: 'OCTET_STREAM',
+  code: raw.code,
+  mediaType: CONTENT_TYPE_OCTET_STREAM.mediaType,
+  encoded () {
+    return json.encode(fixtureWithoutCID)
+  },
+  decode (buf) {
+    expect(json.decode(buf)).to.deep.equal(fixtureWithoutCID)
+  }
+}
+
+export const CBOR: Codec = {
+  name: 'CBOR',
+  code: CODEC_CBOR,
+  mediaType: CONTENT_TYPE_CBOR.mediaType,
+  encoded () {
+    return dagCbor.encode(fixtureWithoutCID)
+  },
+  decode (buf) {
+    expect(dagCbor.decode(buf)).to.deep.equal(fixtureWithoutCID)
+  }
+}
+
+export const DAG_CBOR: Codec = {
+  name: 'DAG-CBOR',
+  code: dagCbor.code,
+  mediaType: CONTENT_TYPE_DAG_CBOR.mediaType,
+  encoded () {
+    return dagCbor.encode(fixtureWithCID)
+  },
+  decode (buf) {
+    expect(dagCbor.decode(buf)).to.deep.equal(fixtureWithCID)
+  }
+}
+
+export const JSON: Codec = {
+  name: 'JSON',
+  code: json.code,
+  mediaType: CONTENT_TYPE_JSON.mediaType,
+  encoded () {
+    return json.encode(fixtureWithoutCID)
+  },
+  decode (buf) {
+    expect(json.decode(buf)).to.deep.equal(fixtureWithoutCID)
+  }
+}
+
+export const DAG_JSON: Codec = {
+  name: 'DAG-JSON',
+  code: dagJson.code,
+  mediaType: CONTENT_TYPE_DAG_JSON.mediaType,
+  encoded () {
+    return dagJson.encode(fixtureWithCID)
+  },
+  decode (buf) {
+    expect(dagJson.decode(buf)).to.deep.equal(fixtureWithCID)
+  }
+}
+
+export const CBOR_TRANSLATIONS: CodecTranslation[] = [{
+  ok: true,
+  input: CBOR,
+  output: CBOR
+}, {
+  ok: false,
+  input: CBOR,
+  output: DAG_CBOR
+}, {
+  ok: false,
+  input: CBOR,
+  output: JSON
+}, {
+  ok: false,
+  input: CBOR,
+  output: DAG_JSON
+}, {
+  ok: true,
+  input: CBOR,
+  output: RAW
+}, {
+  ok: true,
+  input: CBOR,
+  output: OCTET_STREAM
+}]
+
+export const DAG_CBOR_TRANSLATIONS: CodecTranslation[] = [{
+  ok: true,
+  input: DAG_CBOR,
+  output: CBOR
+}, {
+  ok: true,
+  input: DAG_CBOR,
+  output: DAG_CBOR
+}, {
+  ok: false,
+  input: DAG_CBOR,
+  output: JSON
+}, {
+  ok: false,
+  input: DAG_CBOR,
+  output: DAG_JSON
+}, {
+  ok: true,
+  input: DAG_CBOR,
+  output: RAW
+}, {
+  ok: true,
+  input: DAG_CBOR,
+  output: OCTET_STREAM
+}]
+
+export const JSON_TRANSLATIONS: CodecTranslation[] = [{
+  ok: false,
+  input: JSON,
+  output: CBOR
+}, {
+  ok: false,
+  input: JSON,
+  output: DAG_CBOR
+}, {
+  ok: true,
+  input: JSON,
+  output: JSON
+}, {
+  ok: false,
+  input: JSON,
+  output: DAG_JSON
+}, {
+  ok: true,
+  input: JSON,
+  output: RAW
+}, {
+  ok: true,
+  input: JSON,
+  output: OCTET_STREAM
+}]
+
+export const DAG_JSON_TRANSLATIONS: CodecTranslation[] = [{
+  ok: false,
+  input: DAG_JSON,
+  output: CBOR
+}, {
+  ok: false,
+  input: DAG_JSON,
+  output: DAG_CBOR
+}, {
+  ok: true,
+  input: DAG_JSON,
+  output: JSON
+}, {
+  ok: true,
+  input: DAG_JSON,
+  output: DAG_JSON
+}, {
+  ok: true,
+  input: DAG_JSON,
+  output: RAW
+}, {
+  ok: true,
+  input: DAG_JSON,
+  output: OCTET_STREAM
+}]

--- a/packages/verified-fetch/test/json.spec.ts
+++ b/packages/verified-fetch/test/json.spec.ts
@@ -1,15 +1,15 @@
-import * as dagCbor from '@ipld/dag-cbor'
 import { stop } from '@libp2p/interface'
 import { expect } from 'aegir/chai'
 import { CID } from 'multiformats'
+import * as json from 'multiformats/codecs/json'
 import { sha256 } from 'multiformats/hashes/sha2'
-import { MEDIA_TYPE_DAG_CBOR, MEDIA_TYPE_OCTET_STREAM, MEDIA_TYPE_RAW } from '../src/index.ts'
+import { MEDIA_TYPE_JSON, MEDIA_TYPE_OCTET_STREAM, MEDIA_TYPE_RAW } from '../src/index.ts'
 import { VerifiedFetch } from '../src/verified-fetch.ts'
-import { DAG_CBOR_TRANSLATIONS } from './fixtures/codecs.ts'
+import { JSON_TRANSLATIONS } from './fixtures/codecs.ts'
 import { createHelia } from './fixtures/create-offline-helia.js'
 import type { Helia } from 'helia'
 
-describe('dag-cbor', () => {
+describe('json', () => {
   let helia: Helia
   let verifiedFetch: VerifiedFetch
 
@@ -22,29 +22,28 @@ describe('dag-cbor', () => {
     await stop(helia, verifiedFetch)
   })
 
-  it('should download DAG-CBOR blocks as application/vnd.ipld.dag-cbor by default', async () => {
+  it('should download JSON blocks as application/json by default', async () => {
     const obj = {
-      hello: 'world',
-      link: CID.parse('bafkqaddimvwgy3zao5xxe3debi')
+      hello: 'world'
     }
-    const block = dagCbor.encode(obj)
+    const block = json.encode(obj)
     const digest = await sha256.digest(block)
-    const cid = CID.createV1(dagCbor.code, digest)
+    const cid = CID.createV1(json.code, digest)
 
     await helia.blockstore.put(cid, block)
 
     const res = await verifiedFetch.fetch(`/ipfs/${cid}`)
     expect(res.ok).to.be.true()
-    expect(res.headers.get('content-type')).to.equal(MEDIA_TYPE_DAG_CBOR)
+    expect(res.headers.get('content-type')).to.equal(MEDIA_TYPE_JSON)
     expect(res.headers.get('cache-control')).to.equal('public, max-age=29030400, immutable')
 
     const body = await res.arrayBuffer()
-    const decoded = dagCbor.decode(new Uint8Array(body))
+    const decoded = json.decode(new Uint8Array(body))
 
     expect(decoded).to.deep.equal(obj)
   })
 
-  for (const translation of DAG_CBOR_TRANSLATIONS) {
+  for (const translation of JSON_TRANSLATIONS) {
     // eslint-disable-next-line no-loop-func
     it(`${translation.ok ? 'can' : 'can not'} download ${translation.input.name} blocks as ${translation.output.name}`, async () => {
       const buf = translation.input.encoded()

--- a/packages/verified-fetch/test/verified-fetch.spec.ts
+++ b/packages/verified-fetch/test/verified-fetch.spec.ts
@@ -487,49 +487,6 @@ describe('@helia/verified-fetch', () => {
       await expect(j.add(output)).to.eventually.deep.equal(cid)
     })
 
-    it('should handle JSON-compliant dag-cbor block', async () => {
-      const obj = {
-        hello: 'world'
-      }
-      const c = dagCbor(helia)
-      const cid = await c.add(obj)
-
-      const resp = await verifiedFetch.fetch(cid, {
-        headers: {
-          accept: 'application/json'
-        }
-      })
-      expect(resp).to.be.ok()
-      expect(resp.status).to.equal(200)
-      expect(resp.statusText).to.equal('OK')
-      expect(resp.headers.get('content-type')).to.equal('application/json')
-      await expect(resp.json()).to.eventually.deep.equal(obj)
-    })
-
-    it('should return dag-cbor data with embedded CID', async () => {
-      const obj = {
-        hello: 'world',
-        link: CID.parse('QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN')
-      }
-      const c = dagCbor(helia)
-      const cid = await c.add(obj)
-
-      const resp = await verifiedFetch.fetch(cid, {
-        headers: {
-          accept: 'application/json'
-        }
-      })
-      expect(resp.headers.get('content-type')).to.equal('application/json')
-
-      const data = await ipldJson.decode(await resp.arrayBuffer())
-      expect(data).to.deep.equal({
-        hello: 'world',
-        link: {
-          '/': 'QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN'
-        }
-      })
-    })
-
     it('should return dag-cbor data with embedded bytes', async () => {
       const obj = {
         hello: 'world',
@@ -545,47 +502,7 @@ describe('@helia/verified-fetch', () => {
       expect(data).to.deep.equal(obj)
     })
 
-    it('should allow parsing dag-cbor object array buffer as dag-json', async () => {
-      const obj = {
-        hello: 'world'
-      }
-      const c = dagCbor(helia)
-      const cid = await c.add(obj)
-
-      const resp = await verifiedFetch.fetch(cid, {
-        headers: {
-          accept: 'application/json'
-        }
-      })
-      expect(resp.headers.get('content-type')).to.equal('application/json')
-
-      const data = ipldDagJson.decode(await resp.arrayBuffer())
-      expect(data).to.deep.equal(obj)
-    })
-
-    it('should return dag-cbor with a small BigInt as application/json', async () => {
-      const obj = {
-        hello: 'world',
-        bigInt: 10n
-      }
-      const c = dagCbor(helia)
-      const cid = await c.add(obj)
-
-      const resp = await verifiedFetch.fetch(cid, {
-        headers: {
-          accept: 'application/json'
-        }
-      })
-      expect(resp.headers.get('content-type')).to.equal('application/json')
-
-      const data = await resp.json()
-      expect(data).to.deep.equal({
-        hello: 'world',
-        bigInt: 10
-      })
-    })
-
-    it('should return dag-cbor with a large BigInt as application/cbor', async () => {
+    it('should return dag-cbor with a large BigInt as application/vnd.ipld.dag-cbor', async () => {
       const obj = {
         hello: 'world',
         bigInt: BigInt(Number.MAX_SAFE_INTEGER) + 1n
@@ -598,45 +515,6 @@ describe('@helia/verified-fetch', () => {
 
       const data = ipldDagCbor.decode(await resp.arrayBuffer())
       expect(data).to.deep.equal(obj)
-    })
-
-    it('can round trip JSON-compliant dag-cbor via .json()', async () => {
-      const obj = {
-        hello: 'world'
-      }
-      const c = dagCbor(helia)
-      const cid = await c.add(obj)
-
-      const resp = await verifiedFetch.fetch(cid, {
-        headers: {
-          accept: 'application/json'
-        }
-      })
-      expect(resp.headers.get('content-type')).to.equal('application/json')
-
-      const output = await resp.json()
-      await expect(c.add(output)).to.eventually.deep.equal(cid)
-    })
-
-    // N.b. this is not possible because the incoming block is turned into JSON
-    // and returned as the response body, so `.arrayBuffer()` returns a string
-    // encoded into a Uint8Array which we can't parse as CBOR
-    it.skip('can round trip JSON-compliant dag-cbor via .arrayBuffer()', async () => {
-      const obj = {
-        hello: 'world'
-      }
-      const c = dagCbor(helia)
-      const cid = await c.add(obj)
-
-      const resp = await verifiedFetch.fetch(cid, {
-        headers: {
-          accept: 'application/json'
-        }
-      })
-      expect(resp.headers.get('content-type')).to.equal('application/json')
-
-      const output = ipldDagCbor.decode(await resp.arrayBuffer())
-      await expect(c.add(output)).to.eventually.deep.equal(cid)
     })
 
     it('can round trip dag-cbor via .arrayBuffer()', async () => {


### PR DESCRIPTION
Prevents invalid conversions, e.g. json -> dag-json, cbor -> dag-cbor, etc in line with [IPIP-0524](https://github.com/ipfs/specs/pull/524).

These cannot be supported since the dag-* flavour of these codecs restrict field types, enforce field ordering, etc to ensure CID generation is consistent, which cannot be guaranteed by the less restrictive version.

Also updates the acceptable representations for blocks as 406s were being returned with the requested representation in the list of acceptable representations.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
