### PR TITLE
fix: sniff content-type in plugin-handle-raw

### DIFF
--- a/.github/dictionary.txt
+++ b/.github/dictionary.txt
@@ -23,3 +23,8 @@ zcash
 unavail
 bagqbeaawn
 bagqbeaa
+JFIF
+ftyp
+isom
+EBML
+matroska

--- a/packages/verified-fetch/src/plugins/plugin-handle-raw.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-raw.ts
@@ -1,3 +1,4 @@
+import { isPromise } from '@libp2p/utils'
 import toBuffer from 'it-to-buffer'
 import { MEDIA_TYPE_OCTET_STREAM, MEDIA_TYPE_RAW } from '../utils/content-types.ts'
 import { getContentDispositionFilename } from '../utils/get-content-disposition-filename.ts'
@@ -21,13 +22,34 @@ export class RawPlugin extends BasePlugin {
   }
 
   async handle (context: PluginContext): Promise<Response> {
-    const { url, resource, accept, ipfsRoots, terminalElement, blockstore } = context
+    const { url, resource, accept, ipfsRoots, terminalElement, blockstore, requestedMimeTypes } = context
 
     this.log.trace('fetching %c%s', terminalElement.cid, url.pathname)
     const block = await toBuffer(blockstore.get(terminalElement.cid, context))
 
-    const contentType = accept
+    let contentType = accept
       .find(value => value.contentType.mediaType === MEDIA_TYPE_RAW || value.contentType.mediaType === MEDIA_TYPE_OCTET_STREAM)?.contentType.mediaType ?? MEDIA_TYPE_RAW
+
+    // path-gateway spec §3.2.4: sniff bytes unless the request explicitly carries raw or octet-stream
+    const userAcceptedRaw = requestedMimeTypes.some(value =>
+      value.mediaType === MEDIA_TYPE_RAW || value.mediaType === MEDIA_TYPE_OCTET_STREAM
+    )
+
+    if (contentType === MEDIA_TYPE_RAW && !userAcceptedRaw && this.pluginOptions.contentTypeParser != null) {
+      const filename = url.searchParams.get('filename') ?? undefined
+
+      try {
+        const parsed = this.pluginOptions.contentTypeParser(block, filename)
+        const sniffed = isPromise(parsed) ? await parsed : parsed
+
+        if (sniffed != null) {
+          this.log.trace('sniffed content type %s for raw block %c', sniffed, terminalElement.cid)
+          contentType = sniffed
+        }
+      } catch (err) {
+        this.log.error('error parsing content type - %e', err)
+      }
+    }
 
     const headers = {
       'content-length': `${block.byteLength}`,

--- a/packages/verified-fetch/test/raw.spec.ts
+++ b/packages/verified-fetch/test/raw.spec.ts
@@ -8,12 +8,54 @@ import * as raw from 'multiformats/codecs/raw'
 import { sha256 } from 'multiformats/hashes/sha2'
 import { stubInterface } from 'sinon-ts'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
-import { MEDIA_TYPE_DAG_CBOR, MEDIA_TYPE_DAG_JSON } from '../src/index.ts'
+import { MEDIA_TYPE_DAG_CBOR, MEDIA_TYPE_DAG_JSON, MEDIA_TYPE_OCTET_STREAM, MEDIA_TYPE_RAW } from '../src/index.ts'
 import { VerifiedFetch } from '../src/verified-fetch.js'
 import { createHelia } from './fixtures/create-offline-helia.js'
 import type { Helia } from '@helia/interface'
 import type { IPNSResolver } from '@helia/ipns'
 import type { StubbedInstance } from 'sinon-ts'
+
+const PNG_BYTES = Uint8Array.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+  0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+  0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4,
+  0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41,
+  0x54, 0x78, 0x9c, 0x62, 0x00, 0x01, 0x00, 0x00,
+  0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00,
+  0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae,
+  0x42, 0x60, 0x82
+])
+
+const PDF_BYTES = Uint8Array.from([
+  // %PDF-1.4 header followed by minimal valid-ish content for file-type sniffing
+  0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34,
+  0x0a, 0x25, 0xc4, 0xe5, 0xf2, 0xe5, 0xeb, 0xa7,
+  0xf3, 0xa0, 0xd0, 0xc4, 0xc6, 0x0a
+])
+
+// Minimal JPEG: SOI + APP0/JFIF + EOI
+const JPEG_BYTES = Uint8Array.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46,
+  0x49, 0x46, 0x00, 0x01, 0x01, 0x00, 0x00, 0x01,
+  0x00, 0x01, 0x00, 0x00, 0xff, 0xd9
+])
+
+// Minimal MP4 ftyp box (ISO base media, brand "isom")
+const MP4_BYTES = Uint8Array.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70,
+  0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x00, 0x00,
+  0x69, 0x73, 0x6f, 0x6d, 0x6d, 0x70, 0x34, 0x31
+])
+
+// EBML header announcing the matroska/webm DocType
+const WEBM_BYTES = Uint8Array.from([
+  0x1a, 0x45, 0xdf, 0xa3, 0x9f, 0x42, 0x86, 0x81,
+  0x01, 0x42, 0xf7, 0x81, 0x01, 0x42, 0xf2, 0x81,
+  0x04, 0x42, 0xf3, 0x81, 0x08, 0x42, 0x82, 0x84,
+  0x77, 0x65, 0x62, 0x6d, 0x42, 0x87, 0x81, 0x02,
+  0x42, 0x85, 0x81, 0x02
+])
 
 interface Format {
   name: string
@@ -179,5 +221,125 @@ describe('raw blocks', () => {
       }
     })
     expect(res.status).to.equal(406)
+  })
+
+  // codec 0xc0 is zcash-block, which UnixFS and IPLD ignore, so the block falls through to plugin-handle-raw.
+  describe('content-type sniffing (path-gateway spec §3.2.4)', () => {
+    async function putUnsupportedCodecBlock (block: Uint8Array): Promise<CID> {
+      const digest = await sha256.digest(block)
+      const cid = CID.createV1(0xc0, digest)
+      await helia.blockstore.put(cid, block)
+      return cid
+    }
+
+    it('sniffs PNG bytes when no Accept is set', async () => {
+      const cid = await putUnsupportedCodecBlock(PNG_BYTES)
+
+      const res = await verifiedFetch.fetch(`ipfs://${cid}`)
+      expect(res.status).to.equal(200)
+      expect(res.headers.get('content-type')).to.equal('image/png')
+      expect(res.headers.get('content-length')).to.equal(PNG_BYTES.byteLength.toString())
+
+      const buf = new Uint8Array(await res.arrayBuffer())
+      expect(buf).to.equalBytes(PNG_BYTES)
+    })
+
+    it('sniffs PDF bytes when no Accept is set', async () => {
+      const cid = await putUnsupportedCodecBlock(PDF_BYTES)
+
+      const res = await verifiedFetch.fetch(`ipfs://${cid}`)
+      expect(res.status).to.equal(200)
+      expect(res.headers.get('content-type')).to.equal('application/pdf')
+
+      const buf = new Uint8Array(await res.arrayBuffer())
+      expect(buf).to.equalBytes(PDF_BYTES)
+    })
+
+    it('sniffs JPEG bytes when no Accept is set', async () => {
+      const cid = await putUnsupportedCodecBlock(JPEG_BYTES)
+
+      const res = await verifiedFetch.fetch(`ipfs://${cid}`)
+      expect(res.status).to.equal(200)
+      expect(res.headers.get('content-type')).to.equal('image/jpeg')
+    })
+
+    it('sniffs MP4 bytes when no Accept is set', async () => {
+      const cid = await putUnsupportedCodecBlock(MP4_BYTES)
+
+      const res = await verifiedFetch.fetch(`ipfs://${cid}`)
+      expect(res.status).to.equal(200)
+      expect(res.headers.get('content-type')).to.equal('video/mp4')
+    })
+
+    it('sniffs WebM bytes when no Accept is set', async () => {
+      const cid = await putUnsupportedCodecBlock(WEBM_BYTES)
+
+      const res = await verifiedFetch.fetch(`ipfs://${cid}`)
+      expect(res.status).to.equal(200)
+      expect(res.headers.get('content-type')).to.equal('video/webm')
+    })
+
+    it('sniffs JSON bytes when no Accept is set', async () => {
+      const block = uint8ArrayFromString('{"hello":"world"}')
+      const cid = await putUnsupportedCodecBlock(block)
+
+      const res = await verifiedFetch.fetch(`ipfs://${cid}`)
+      expect(res.status).to.equal(200)
+      expect(res.headers.get('content-type')).to.equal('application/json')
+    })
+
+    it('sniffs plain text bytes when no Accept is set', async () => {
+      const block = uint8ArrayFromString('hello from a text file')
+      const cid = await putUnsupportedCodecBlock(block)
+
+      const res = await verifiedFetch.fetch(`ipfs://${cid}`)
+      expect(res.status).to.equal(200)
+      expect(res.headers.get('content-type')).to.equal('text/plain; charset=utf-8')
+    })
+
+    it('keeps application/vnd.ipld.raw when contentTypeParser cannot classify the bytes', async () => {
+      const block = uint8ArrayFromString('hello')
+      const cid = await putUnsupportedCodecBlock(block)
+
+      const customFetch = new VerifiedFetch(helia, {
+        ipnsResolver,
+        // simulate a parser that cannot identify the bytes
+        contentTypeParser: () => undefined
+      })
+
+      try {
+        const res = await customFetch.fetch(`ipfs://${cid}`)
+        expect(res.status).to.equal(200)
+        expect(res.headers.get('content-type')).to.equal(MEDIA_TYPE_RAW)
+      } finally {
+        await stop(customFetch)
+      }
+    })
+
+    it('returns application/vnd.ipld.raw when explicitly requested even for PNG bytes', async () => {
+      const cid = await putUnsupportedCodecBlock(PNG_BYTES)
+
+      const res = await verifiedFetch.fetch(`ipfs://${cid}`, {
+        headers: { accept: MEDIA_TYPE_RAW }
+      })
+      expect(res.status).to.equal(200)
+      expect(res.headers.get('content-type')).to.equal(MEDIA_TYPE_RAW)
+
+      const buf = new Uint8Array(await res.arrayBuffer())
+      expect(buf).to.equalBytes(PNG_BYTES)
+    })
+
+    it('returns application/octet-stream when explicitly requested even for PNG bytes', async () => {
+      const cid = await putUnsupportedCodecBlock(PNG_BYTES)
+
+      const res = await verifiedFetch.fetch(`ipfs://${cid}`, {
+        headers: { accept: MEDIA_TYPE_OCTET_STREAM }
+      })
+      expect(res.status).to.equal(200)
+      expect(res.headers.get('content-type')).to.equal(MEDIA_TYPE_OCTET_STREAM)
+
+      const buf = new Uint8Array(await res.arrayBuffer())
+      expect(buf).to.equalBytes(PNG_BYTES)
+    })
   })
 })


### PR DESCRIPTION
> [!IMPORTANT]
> This PR exists because of problem described in https://github.com/ipfs/service-worker-gateway/pull/1039/changes#r3164916318

`plugin-handle-raw` returned `application/vnd.ipld.raw` whenever no `Accept` entry matched `raw` or `octet-stream`, even for blocks whose bytes carried PNG, PDF, or MP4 magic. This breaks path-gateway spec §3.2.4, which requires content-type sniffing on deserialized responses when no explicit response format was requested.

The fix runs the same `contentTypeParser` plugin-handle-unixfs uses, only when the request did not explicitly carry raw or octet-stream in `Accept`. `?format=raw` and `Accept: application/vnd.ipld.raw` paths still return `application/vnd.ipld.raw` byte-for-byte.

The SW gateway worked around this in ipfs/service-worker-gateway#1039 by re-running `fileTypeFromBuffer` on every response that came back as raw. Sniffing upstream (this PR, in verified-fetch) lets that workaround go and avoids two copies of the same detection logic across the two repos.


