### PR TITLE
fix: list shard entries

### DIFF
--- a/packages/verified-fetch/src/plugins/plugin-handle-unixfs.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-unixfs.ts
@@ -1,4 +1,4 @@
-import { code as dagPbCode } from '@ipld/dag-pb'
+import * as dagPb from '@ipld/dag-pb'
 import { isPromise } from '@libp2p/utils'
 import { exporter, walkPath } from 'ipfs-unixfs-exporter'
 import first from 'it-first'
@@ -44,7 +44,7 @@ function getDirectoryRedirectUrl (resource: Resource, url: URL): string | undefi
  */
 export class UnixFSPlugin extends BasePlugin {
   readonly id = 'unixfs-plugin'
-  readonly codes = [dagPbCode, raw.code]
+  readonly codes = [dagPb.code, raw.code]
 
   canHandle ({ terminalElement, accept }: PluginContext): boolean {
     const supportsCid = this.codes.includes(terminalElement.cid.code)
@@ -132,7 +132,26 @@ export class UnixFSPlugin extends BasePlugin {
       }
 
       // no index file found, return the directory listing
-      const block = await toBuffer(context.blockstore.get(dirCid, context))
+      let block = await toBuffer(context.blockstore.get(dirCid, context))
+
+      // if it's a shard, load all entries
+      // TODO: partial shard responses
+      if (entry.unixfs.type === 'hamt-sharded-directory') {
+        const links: dagPb.PBLink[] = []
+        const data = dagPb.decode(block)
+
+        for await (const dirEntry of entry.entries()) {
+          links.push({
+            Name: dirEntry.name,
+            Hash: dirEntry.cid
+          })
+        }
+
+        block = dagPb.encode({
+          Data: data.Data,
+          Links: links.sort((a, b) => a.Name?.localeCompare(b.Name ?? '') ?? 0)
+        })
+      }
 
       return okResponse(resource, block, {
         headers: {
@@ -142,7 +161,8 @@ export class UnixFSPlugin extends BasePlugin {
             getContentDispositionFilename(`${dirCid}.dir`)
           }`,
           'x-ipfs-roots': ipfsRoots.map(cid => cid.toV1()).join(','),
-          'accept-ranges': 'bytes'
+          'accept-ranges': 'bytes',
+          'x-unixfs-type': entry.unixfs.type
         },
         redirected
       })
@@ -178,7 +198,8 @@ export class UnixFSPlugin extends BasePlugin {
             getContentDispositionFilename(filename)
           }`,
           'x-ipfs-roots': ipfsRoots.map(cid => cid.toV1()).join(','),
-          'accept-ranges': 'bytes'
+          'accept-ranges': 'bytes',
+          'x-unixfs-type': entry.type
         },
         redirected
       })
@@ -194,7 +215,8 @@ export class UnixFSPlugin extends BasePlugin {
           getContentDispositionFilename(filename)
         }`,
         'x-ipfs-roots': ipfsRoots.map(cid => cid.toV1()).join(','),
-        'accept-ranges': 'bytes'
+        'accept-ranges': 'bytes',
+        'x-unixfs-type': entry.type
       },
       redirected
     })

--- a/packages/verified-fetch/test/dag-pb.spec.ts
+++ b/packages/verified-fetch/test/dag-pb.spec.ts
@@ -48,8 +48,17 @@ const fixtures: Record<string, UnixFSFixtures> = {
       shard: {
         contentType: MEDIA_TYPE_DAG_PB,
         async verify (res, cid, helia) {
-          expect(dagPb.decode(new Uint8Array(await res.arrayBuffer())))
-            .to.deep.equal(dagPb.decode(await toBuffer(helia.blockstore.get(cid))))
+          const actual = dagPb.decode(new Uint8Array(await res.arrayBuffer()))
+          const expected = dagPb.decode(await toBuffer(helia.blockstore.get(cid)))
+
+          expect(actual)
+            .to.deep.equal({
+              Data: expected.Data,
+              Links: expected.Links.map((link, index) => ({
+                Hash: link.Hash,
+                Name: link.Name?.substring(2)
+              }))
+            })
         }
       }
     }


### PR DESCRIPTION
When a shard without an index.html file is encountered, collect all the shard entries to show a directory listing in a similar way to the Kubo HTTP gateway.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
