### PR TITLE
fix: return empty 200 for empty files

### DIFF
--- a/packages/verified-fetch/src/plugins/plugin-handle-unixfs.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-unixfs.ts
@@ -16,6 +16,8 @@ import type { AbortOptions } from '@libp2p/interface'
 import type { IdentityNode, RawNode, UnixFSEntry, UnixFSFile } from 'ipfs-unixfs-exporter'
 import type { CID } from 'multiformats/cid'
 
+const EMPTY = new Uint8Array(0)
+
 /**
  * @see https://specs.ipfs.tech/http-gateways/path-gateway/#use-in-directory-url-normalization
  */
@@ -183,7 +185,7 @@ export class UnixFSPlugin extends BasePlugin {
 
     // only detect content type for non-range requests to avoid loading blocks
     // we aren't going to stream to the user
-    if (rangeHeader == null && entry.size > 0n) {
+    if (rangeHeader == null) {
       contentType = await this.detectContentType(entry, filename, options)
     }
 
@@ -236,7 +238,7 @@ export class UnixFSPlugin extends BasePlugin {
     }
 
     if (buf == null) {
-      throw new Error('stream ended before first block was read')
+      buf = EMPTY
     }
 
     let contentType: string | undefined

--- a/packages/verified-fetch/src/plugins/plugin-handle-unixfs.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-unixfs.ts
@@ -183,7 +183,7 @@ export class UnixFSPlugin extends BasePlugin {
 
     // only detect content type for non-range requests to avoid loading blocks
     // we aren't going to stream to the user
-    if (rangeHeader == null) {
+    if (rangeHeader == null && entry.size > 0n) {
       contentType = await this.detectContentType(entry, filename, options)
     }
 

--- a/packages/verified-fetch/test/content-type-parser.spec.ts
+++ b/packages/verified-fetch/test/content-type-parser.spec.ts
@@ -105,6 +105,17 @@ describe('content-type-parser', () => {
     expect(resp.headers.get('content-disposition')).to.include('filename="hello.cjs"')
   })
 
+  it('should detect empty file as application/octet-stream', async () => {
+    const cid = await fs.addBytes(new Uint8Array(0))
+
+    verifiedFetch = new VerifiedFetch(helia)
+    const resp = await verifiedFetch.fetch(`ipfs://${cid}`)
+    expect(resp.status).to.equal(200)
+    expect(resp.headers.get('content-length')).to.equal('0')
+    expect(resp.headers.get('content-type')).to.equal('application/octet-stream')
+    expect(resp.headers.get('content-disposition')).to.include(`filename="${cid}"`)
+  })
+
   it('is passed a filename if it is available', async () => {
     const dir = await fs.addDirectory()
     const index = await fs.addBytes(uint8ArrayFromString('<html><body>Hello world</body></html>'))

--- a/packages/verified-fetch/test/content-type-parser.spec.ts
+++ b/packages/verified-fetch/test/content-type-parser.spec.ts
@@ -105,14 +105,14 @@ describe('content-type-parser', () => {
     expect(resp.headers.get('content-disposition')).to.include('filename="hello.cjs"')
   })
 
-  it('should detect empty file as application/octet-stream', async () => {
+  it('should detect empty file as text/plain; charset=utf-8', async () => {
     const cid = await fs.addBytes(new Uint8Array(0))
 
     verifiedFetch = new VerifiedFetch(helia)
     const resp = await verifiedFetch.fetch(`ipfs://${cid}`)
     expect(resp.status).to.equal(200)
     expect(resp.headers.get('content-length')).to.equal('0')
-    expect(resp.headers.get('content-type')).to.equal('application/octet-stream')
+    expect(resp.headers.get('content-type')).to.equal('text/plain; charset=utf-8')
     expect(resp.headers.get('content-disposition')).to.include(`filename="${cid}"`)
   })
 


### PR DESCRIPTION
Instead of erroring, return an empty response for empty files.

Refs: https://github.com/ipfs/service-worker-gateway/issues/1087

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
