### PR TITLE
fix: add cache-control directives and expires header to responses

### DIFF
--- a/packages/verified-fetch/src/index.ts
+++ b/packages/verified-fetch/src/index.ts
@@ -1359,7 +1359,7 @@ export interface ResolveURLResult {
    * How long this result is valid for - in general re-resolving this URL will
    * result in the same final URL within this many seconds
    */
-  ttl: number
+  ttl?: number
 
   /**
    * This can represent an IPNS records EOL validity expiration

--- a/packages/verified-fetch/src/index.ts
+++ b/packages/verified-fetch/src/index.ts
@@ -1354,7 +1354,18 @@ export interface ResolveURLOptions extends AbortOptions, ProviderOptions, Progre
 
 export interface ResolveURLResult {
   url: URL
+
+  /**
+   * How long this result is valid for - in general re-resolving this URL will
+   * result in the same final URL within this many seconds
+   */
   ttl: number
+
+  /**
+   * This can represent an IPNS records EOL validity expiration
+   */
+  expires?: Date
+
   blockstore: Blockstore
   ipfsRoots: CID[]
   terminalElement: PathEntry

--- a/packages/verified-fetch/src/plugins/plugin-handle-ipns-record.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-ipns-record.ts
@@ -19,7 +19,7 @@ export class IpnsRecordPlugin extends BasePlugin {
     return accept.some(header => header.contentType.mediaType === MEDIA_TYPE_IPNS_RECORD)
   }
 
-  async handle (context: Pick<PluginContext, 'resource' | 'url' | 'range' | 'redirected' | 'signal' | 'onProgress'>): Promise<Response> {
+  async handle (context: Pick<PluginContext, 'resource' | 'url' | 'range' | 'redirected' | 'signal' | 'onProgress' | 'ttl' | 'expires'>): Promise<Response> {
     const { resource, url, range } = context
     const { ipnsResolver } = this.pluginOptions
 
@@ -46,31 +46,24 @@ export class IpnsRecordPlugin extends BasePlugin {
     const result = await ipnsResolver.resolve(peerId, context)
     const block = marshalIPNSRecord(result.record)
 
-    const maxAge = Math.round(Number((result.record.ttl ?? 0n) / BigInt(1e9)))
-
-    const headers: Record<string, string> = {
-      'content-length': `${block.byteLength}`,
-      'content-type': CONTENT_TYPE_IPNS.mediaType,
-      'content-disposition': `attachment; ${
-        getContentDispositionFilename(url.searchParams.get('filename') ?? `${peerId}${CONTENT_TYPE_IPNS.extension}`)
-      }`,
-      'x-ipfs-roots': result.cid.toV1().toString(),
-      'cache-control': `public, max-age=${maxAge}`,
-      'accept-ranges': 'none'
-    }
-
     if (result.record.validityType === 'EOL') {
       const eol = new Date(result.record.validity)
-      headers.expires = eol.toUTCString()
 
-      const lifetimeRemaining = Math.max(0, Math.round((eol.getTime() - Date.now()) / 1000))
-
-      headers['cache-control'] += `, stale-while-revalidate=${lifetimeRemaining}, stale-if-error=${lifetimeRemaining}`
+      context.expires = eol
+      context.ttl = Math.round(Number((result.record.ttl ?? 0n) / BigInt(1e9)))
     }
 
     return okResponse(resource, block, {
       redirected: context.redirected,
-      headers
+      headers: {
+        'content-length': `${block.byteLength}`,
+        'content-type': CONTENT_TYPE_IPNS.mediaType,
+        'content-disposition': `attachment; ${
+          getContentDispositionFilename(url.searchParams.get('filename') ?? `${peerId}${CONTENT_TYPE_IPNS.extension}`)
+        }`,
+        'x-ipfs-roots': result.cid.toV1().toString(),
+        'accept-ranges': 'none'
+      }
     })
   }
 }

--- a/packages/verified-fetch/src/plugins/plugin-handle-ipns-record.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-ipns-record.ts
@@ -63,7 +63,7 @@ export class IpnsRecordPlugin extends BasePlugin {
       const eol = new Date(result.record.validity)
       headers.expires = eol.toUTCString()
 
-      const lifetimeRemaining = Math.round(((eol.getTime() - Date.now()) / 1000))
+      const lifetimeRemaining = Math.max(0, Math.round((eol.getTime() - Date.now()) / 1000))
 
       headers['cache-control'] += `, stale-while-revalidate=${lifetimeRemaining}, stale-if-error=${lifetimeRemaining}`
     }

--- a/packages/verified-fetch/src/plugins/plugin-handle-ipns-record.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-ipns-record.ts
@@ -46,18 +46,31 @@ export class IpnsRecordPlugin extends BasePlugin {
     const result = await ipnsResolver.resolve(peerId, context)
     const block = marshalIPNSRecord(result.record)
 
+    const maxAge = Number((result.record.ttl ?? 0n) / BigInt(1e9))
+
+    const headers: Record<string, string> = {
+      'content-length': `${block.byteLength}`,
+      'content-type': CONTENT_TYPE_IPNS.mediaType,
+      'content-disposition': `attachment; ${
+        getContentDispositionFilename(url.searchParams.get('filename') ?? `${peerId}${CONTENT_TYPE_IPNS.extension}`)
+      }`,
+      'x-ipfs-roots': result.cid.toV1().toString(),
+      'cache-control': `public, max-age=${maxAge}`,
+      'accept-ranges': 'none'
+    }
+
+    if (result.record.validityType === 'EOL') {
+      const eol = new Date(result.record.validity)
+      headers.expires = eol.toUTCString()
+
+      const lifetimeRemaining = parseInt(((eol.getTime() - Date.now()) / 1000).toString())
+
+      headers['cache-control'] += `, stale-while-revalidate=${lifetimeRemaining}, stale-if-error=${lifetimeRemaining}`
+    }
+
     return okResponse(resource, block, {
       redirected: context.redirected,
-      headers: {
-        'content-length': `${block.byteLength}`,
-        'content-type': CONTENT_TYPE_IPNS.mediaType,
-        'content-disposition': `attachment; ${
-          getContentDispositionFilename(url.searchParams.get('filename') ?? `${peerId}${CONTENT_TYPE_IPNS.extension}`)
-        }`,
-        'x-ipfs-roots': result.cid.toV1().toString(),
-        'cache-control': `public, max-age=${Number((result.record.ttl ?? 0n) / BigInt(1e9))}`,
-        'accept-ranges': 'none'
-      }
+      headers
     })
   }
 }

--- a/packages/verified-fetch/src/plugins/plugin-handle-ipns-record.ts
+++ b/packages/verified-fetch/src/plugins/plugin-handle-ipns-record.ts
@@ -46,7 +46,7 @@ export class IpnsRecordPlugin extends BasePlugin {
     const result = await ipnsResolver.resolve(peerId, context)
     const block = marshalIPNSRecord(result.record)
 
-    const maxAge = Number((result.record.ttl ?? 0n) / BigInt(1e9))
+    const maxAge = Math.round(Number((result.record.ttl ?? 0n) / BigInt(1e9)))
 
     const headers: Record<string, string> = {
       'content-length': `${block.byteLength}`,
@@ -63,7 +63,7 @@ export class IpnsRecordPlugin extends BasePlugin {
       const eol = new Date(result.record.validity)
       headers.expires = eol.toUTCString()
 
-      const lifetimeRemaining = parseInt(((eol.getTime() - Date.now()) / 1000).toString())
+      const lifetimeRemaining = Math.round(((eol.getTime() - Date.now()) / 1000))
 
       headers['cache-control'] += `, stale-while-revalidate=${lifetimeRemaining}, stale-if-error=${lifetimeRemaining}`
     }

--- a/packages/verified-fetch/src/url-resolver.ts
+++ b/packages/verified-fetch/src/url-resolver.ts
@@ -172,11 +172,18 @@ export class URLResolver implements URLResolverInterface {
       return ipfsResult
     }
 
+    let expires: Date | undefined
+
+    if (result.record.validityType === 'EOL') {
+      expires = new Date(result.record.validity)
+    }
+
     return {
       ...ipfsResult,
       url,
       // IPNS ttl is in nanoseconds, convert to seconds
-      ttl: Number((result.record.ttl ?? 0n) / BigInt(1e9))
+      ttl: Number((result.record.ttl ?? 0n) / BigInt(1e9)),
+      expires
     }
   }
 

--- a/packages/verified-fetch/src/url-resolver.ts
+++ b/packages/verified-fetch/src/url-resolver.ts
@@ -181,8 +181,9 @@ export class URLResolver implements URLResolverInterface {
     return {
       ...ipfsResult,
       url,
-      // IPNS ttl is in nanoseconds, convert to seconds
-      ttl: Number((result.record.ttl ?? 0n) / BigInt(1e9)),
+      // IPNS ttl is in nanoseconds, convert to seconds and round to the nearest
+      // integer
+      ttl: Math.round(Number((result.record.ttl ?? 0n) / BigInt(1e9))),
       expires
     }
   }

--- a/packages/verified-fetch/src/utils/response-headers.ts
+++ b/packages/verified-fetch/src/utils/response-headers.ts
@@ -4,42 +4,62 @@ interface CacheControlHeaderOptions {
   /**
    * This should be seconds as a number.
    *
-   * See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#response_directives
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#response_directives
    */
   ttl?: number
+
+  /**
+   * This can represent an IPNS record's EOL validity
+   */
+  expires?: Date
   protocol: string
   response: Response
 }
 
 /**
- * Implementations may place an upper bound on any TTL received, as noted in Section 8 of [rfc2181].
+ * Implementations may place an upper bound on any TTL received, as noted in
+ * Section 8 of [rfc2181].
+ *
  * If TTL value is unknown, implementations should not send a Cache-Control
- * No matter if TTL value is known or not, implementations should always send a Last-Modified header with the timestamp of the record resolution.
+ *
+ * No matter if TTL value is known or not, implementations should always send a
+ * Last-Modified header with the timestamp of the record resolution.
  *
  * @see https://specs.ipfs.tech/http-gateways/path-gateway/#cache-control-response-header
  */
-export function setCacheControlHeader ({ ttl, protocol, response }: CacheControlHeaderOptions): void {
+export function setCacheControlHeader ({ ttl, expires, protocol, response }: CacheControlHeaderOptions): void {
   if (response.headers.has('cache-control')) {
     // don't set the header if it's already set by a plugin
     return
   }
 
-  let headerValue: string
+  let cacheControl: string
 
   if (protocol === 'ipfs:') {
-    headerValue = 'public, max-age=29030400, immutable'
+    cacheControl = 'public, max-age=29030400, immutable'
   } else if (ttl == null) {
     /**
-     * default limit for unknown TTL: "use 5 minute as default fallback when it is not available."
+     * default limit for unknown TTL: "use 5 minute as default fallback when it
+     * is not available."
      *
      * @see https://github.com/ipfs/boxo/issues/329#issuecomment-1995236409
      */
-    headerValue = 'public, max-age=300'
+    cacheControl = 'public, max-age=300'
   } else {
-    headerValue = `public, max-age=${ttl}`
+    cacheControl = `public, max-age=${ttl}`
   }
 
-  response.headers.set('cache-control', headerValue)
+  if (expires != null) {
+    const lifetimeRemaining = parseInt(((expires.getTime() - Date.now()) / 1000).toString())
+    cacheControl += ` stale-while-revalidate=${lifetimeRemaining}, stale-if-error=${lifetimeRemaining}`
+
+    // add the expires header if it's not been set by a plugin
+    if (!response.headers.has('expires')) {
+      response.headers.set('expires', expires.toUTCString())
+    }
+  }
+
+  response.headers.set('cache-control', cacheControl)
 }
 
 /**

--- a/packages/verified-fetch/src/utils/response-headers.ts
+++ b/packages/verified-fetch/src/utils/response-headers.ts
@@ -50,7 +50,7 @@ export function setCacheControlHeader ({ ttl, expires, protocol, response }: Cac
   }
 
   if (expires != null) {
-    const lifetimeRemaining = Math.round((expires.getTime() - Date.now()) / 1000)
+    const lifetimeRemaining = Math.max(0, Math.round((expires.getTime() - Date.now()) / 1000))
     cacheControl += `, stale-while-revalidate=${lifetimeRemaining}, stale-if-error=${lifetimeRemaining}`
 
     // add the expires header if it's not been set by a plugin

--- a/packages/verified-fetch/src/utils/response-headers.ts
+++ b/packages/verified-fetch/src/utils/response-headers.ts
@@ -28,11 +28,6 @@ interface CacheControlHeaderOptions {
  * @see https://specs.ipfs.tech/http-gateways/path-gateway/#cache-control-response-header
  */
 export function setCacheControlHeader ({ ttl, expires, protocol, response }: CacheControlHeaderOptions): void {
-  if (response.headers.has('cache-control')) {
-    // don't set the header if it's already set by a plugin
-    return
-  }
-
   let cacheControl: string
 
   if (protocol === 'ipfs:') {
@@ -59,7 +54,10 @@ export function setCacheControlHeader ({ ttl, expires, protocol, response }: Cac
     }
   }
 
-  response.headers.set('cache-control', cacheControl)
+  if (!response.headers.has('cache-control')) {
+    // don't set the cache-control header if it's already set by a plugin
+    response.headers.set('cache-control', cacheControl)
+  }
 }
 
 /**

--- a/packages/verified-fetch/src/utils/response-headers.ts
+++ b/packages/verified-fetch/src/utils/response-headers.ts
@@ -51,7 +51,7 @@ export function setCacheControlHeader ({ ttl, expires, protocol, response }: Cac
 
   if (expires != null) {
     const lifetimeRemaining = Math.round((expires.getTime() - Date.now()) / 1000)
-    cacheControl += ` stale-while-revalidate=${lifetimeRemaining}, stale-if-error=${lifetimeRemaining}`
+    cacheControl += `, stale-while-revalidate=${lifetimeRemaining}, stale-if-error=${lifetimeRemaining}`
 
     // add the expires header if it's not been set by a plugin
     if (!response.headers.has('expires')) {

--- a/packages/verified-fetch/src/utils/response-headers.ts
+++ b/packages/verified-fetch/src/utils/response-headers.ts
@@ -50,7 +50,7 @@ export function setCacheControlHeader ({ ttl, expires, protocol, response }: Cac
   }
 
   if (expires != null) {
-    const lifetimeRemaining = parseInt(((expires.getTime() - Date.now()) / 1000).toString())
+    const lifetimeRemaining = Math.round((expires.getTime() - Date.now()) / 1000)
     cacheControl += ` stale-while-revalidate=${lifetimeRemaining}, stale-if-error=${lifetimeRemaining}`
 
     // add the expires header if it's not been set by a plugin

--- a/packages/verified-fetch/src/verified-fetch.ts
+++ b/packages/verified-fetch/src/verified-fetch.ts
@@ -198,15 +198,17 @@ export class VerifiedFetch {
           return notAcceptableResponse(resource, requestedMimeTypes, [])
         }
 
-        return this.handleFinalResponse(await ipnsRecordPlugin.handle({
+        const context = {
           ...options,
           range,
           url,
           resource,
-          redirected: false
-        }), withServerTiming, {
+          redirected: false,
           serverTiming
-        })
+        }
+
+        // @ts-expect-error headers type is wrong
+        return this.handleFinalResponse(await ipnsRecordPlugin.handle(context), withServerTiming, context)
       }
 
       const resolveResult = await this.urlResolver.resolve(url, serverTiming, options)

--- a/packages/verified-fetch/src/verified-fetch.ts
+++ b/packages/verified-fetch/src/verified-fetch.ts
@@ -421,6 +421,7 @@ export class VerifiedFetch {
       setCacheControlHeader({
         response,
         ttl: context.ttl,
+        expires: context.expires,
         protocol: context.url.protocol
       })
     }

--- a/packages/verified-fetch/test/ipns-record.spec.ts
+++ b/packages/verified-fetch/test/ipns-record.spec.ts
@@ -57,7 +57,10 @@ describe('ipns records', () => {
     expect(resp.headers.get('content-length')).to.equal(marshaledRecord.byteLength.toString())
     expect(resp.headers.get('x-ipfs-roots')).to.equal(cid.toV1().toString())
     expect(resp.headers.get('content-disposition')).to.equal(`attachment; filename="${peerId}.bin"`)
-    expect(resp.headers.get('cache-control')).to.equal('public, max-age=300')
+    expect(resp.headers.get('cache-control')).to.contain(`public, max-age=${parseInt(Number((record.ttl ?? 0n) / BigInt(1e9)).toString())}`)
+    expect(resp.headers.get('cache-control')).to.contain('stale-while-revalidate=')
+    expect(resp.headers.get('cache-control')).to.contain('stale-if-error=')
+    expect(resp.headers.get('expires')).to.equal(new Date(record.validity).toUTCString())
 
     const buf = new Uint8Array(await resp.arrayBuffer())
     expect(marshalIPNSRecord(record)).to.equalBytes(buf)

--- a/packages/verified-fetch/test/ipns-record.spec.ts
+++ b/packages/verified-fetch/test/ipns-record.spec.ts
@@ -57,7 +57,7 @@ describe('ipns records', () => {
     expect(resp.headers.get('content-length')).to.equal(marshaledRecord.byteLength.toString())
     expect(resp.headers.get('x-ipfs-roots')).to.equal(cid.toV1().toString())
     expect(resp.headers.get('content-disposition')).to.equal(`attachment; filename="${peerId}.bin"`)
-    expect(resp.headers.get('cache-control')).to.contain(`public, max-age=${parseInt(Number((record.ttl ?? 0n) / BigInt(1e9)).toString())}`)
+    expect(resp.headers.get('cache-control')).to.contain(`public, max-age=${Math.round(Number((record.ttl ?? 0n) / BigInt(1e9)))}`)
     expect(resp.headers.get('cache-control')).to.contain('stale-while-revalidate=')
     expect(resp.headers.get('cache-control')).to.contain('stale-if-error=')
     expect(resp.headers.get('expires')).to.equal(new Date(record.validity).toUTCString())

--- a/packages/verified-fetch/test/ipns-record.spec.ts
+++ b/packages/verified-fetch/test/ipns-record.spec.ts
@@ -57,9 +57,8 @@ describe('ipns records', () => {
     expect(resp.headers.get('content-length')).to.equal(marshaledRecord.byteLength.toString())
     expect(resp.headers.get('x-ipfs-roots')).to.equal(cid.toV1().toString())
     expect(resp.headers.get('content-disposition')).to.equal(`attachment; filename="${peerId}.bin"`)
-    expect(resp.headers.get('cache-control')).to.contain(`public, max-age=${Math.round(Number((record.ttl ?? 0n) / BigInt(1e9)))}`)
-    expect(resp.headers.get('cache-control')).to.contain('stale-while-revalidate=')
-    expect(resp.headers.get('cache-control')).to.contain('stale-if-error=')
+    const maxAge = Math.round(Number((record.ttl ?? 0n) / BigInt(1e9)))
+    expect(resp.headers.get('cache-control')).to.match(new RegExp(`^public, max-age=${maxAge}, stale-while-revalidate=\\d+, stale-if-error=\\d+$`))
     expect(resp.headers.get('expires')).to.equal(new Date(record.validity).toUTCString())
 
     const buf = new Uint8Array(await resp.arrayBuffer())

--- a/packages/verified-fetch/test/ipns.spec.ts
+++ b/packages/verified-fetch/test/ipns.spec.ts
@@ -53,7 +53,7 @@ describe('IPNS', () => {
     expect(resp.url).to.equal(`ipns://${peerId}`)
     expect(resp.headers.get('X-Ipfs-Path')).to.equal(`/ipns/${peerId}`)
     expect(resp.headers.get('X-Ipfs-Roots')).to.equal(`${cid}`)
-    expect(resp.headers.get('cache-control')).to.contain(`public, max-age=${parseInt(Number((record.ttl ?? 0n) / BigInt(1e9)).toString())}`)
+    expect(resp.headers.get('cache-control')).to.contain(`public, max-age=${Math.round(Number((record.ttl ?? 0n) / BigInt(1e9)))}`)
     expect(resp.headers.get('cache-control')).to.contain('stale-while-revalidate=')
     expect(resp.headers.get('cache-control')).to.contain('stale-if-error=')
     expect(resp.headers.get('expires')).to.equal(new Date(record.validity).toUTCString())

--- a/packages/verified-fetch/test/ipns.spec.ts
+++ b/packages/verified-fetch/test/ipns.spec.ts
@@ -53,9 +53,8 @@ describe('IPNS', () => {
     expect(resp.url).to.equal(`ipns://${peerId}`)
     expect(resp.headers.get('X-Ipfs-Path')).to.equal(`/ipns/${peerId}`)
     expect(resp.headers.get('X-Ipfs-Roots')).to.equal(`${cid}`)
-    expect(resp.headers.get('cache-control')).to.contain(`public, max-age=${Math.round(Number((record.ttl ?? 0n) / BigInt(1e9)))}`)
-    expect(resp.headers.get('cache-control')).to.contain('stale-while-revalidate=')
-    expect(resp.headers.get('cache-control')).to.contain('stale-if-error=')
+    const maxAge = Math.round(Number((record.ttl ?? 0n) / BigInt(1e9)))
+    expect(resp.headers.get('cache-control')).to.match(new RegExp(`^public, max-age=${maxAge}, stale-while-revalidate=\\d+, stale-if-error=\\d+$`))
     expect(resp.headers.get('expires')).to.equal(new Date(record.validity).toUTCString())
   })
 

--- a/packages/verified-fetch/test/ipns.spec.ts
+++ b/packages/verified-fetch/test/ipns.spec.ts
@@ -53,6 +53,10 @@ describe('IPNS', () => {
     expect(resp.url).to.equal(`ipns://${peerId}`)
     expect(resp.headers.get('X-Ipfs-Path')).to.equal(`/ipns/${peerId}`)
     expect(resp.headers.get('X-Ipfs-Roots')).to.equal(`${cid}`)
+    expect(resp.headers.get('cache-control')).to.contain(`public, max-age=${parseInt(Number((record.ttl ?? 0n) / BigInt(1e9)).toString())}`)
+    expect(resp.headers.get('cache-control')).to.contain('stale-while-revalidate=')
+    expect(resp.headers.get('cache-control')).to.contain('stale-if-error=')
+    expect(resp.headers.get('expires')).to.equal(new Date(record.validity).toUTCString())
   })
 
   it('should resolve an IPNS name with a path', async () => {


### PR DESCRIPTION
Add the `stale-while-revalidate` and `stale-if-error` `cache-control` header directives to responses that resolve an IPNS name, and also an `expires` header that contains the record EOL.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [x] I have added tests that prove my fix is effective or that my feature works
