### PR TITLE
chore: just return overridden fields

### DIFF
--- a/packages/verified-fetch/src/utils/libp2p-defaults.browser.ts
+++ b/packages/verified-fetch/src/utils/libp2p-defaults.browser.ts
@@ -9,12 +9,6 @@ type ServiceMap = Pick<DefaultLibp2pServices, 'dcutr' | 'identify' | 'identifyPu
 
 export function getLibp2pConfig (): Libp2pOptions & Required<Pick<Libp2pOptions, 'services'>> {
   const libp2pDefaultOptions = libp2pDefaults()
-
-  libp2pDefaultOptions.start = false
-  libp2pDefaultOptions.addresses = { listen: [] }
-  libp2pDefaultOptions.transports = [webRTCDirect(), webSockets()]
-  libp2pDefaultOptions.peerDiscovery = [] // Avoid connecting to bootstrap nodes
-
   const services: ServiceFactoryMap<ServiceMap> = {
     dcutr: libp2pDefaultOptions.services.dcutr,
     identify: libp2pDefaultOptions.services.identify,
@@ -24,8 +18,16 @@ export function getLibp2pConfig (): Libp2pOptions & Required<Pick<Libp2pOptions,
   }
 
   return {
-    ...libp2pDefaultOptions,
-    start: false,
+    addresses: {
+      listen: []
+    },
+    transports: [
+      webRTCDirect(),
+      webSockets()
+    ],
+    peerDiscovery: [
+      // Avoid connecting to bootstrap nodes
+    ],
     services
   }
 }

--- a/packages/verified-fetch/src/utils/libp2p-defaults.ts
+++ b/packages/verified-fetch/src/utils/libp2p-defaults.ts
@@ -23,7 +23,6 @@ export function getLibp2pConfig (): Libp2pOptions & Required<Pick<Libp2pOptions,
   }
 
   return {
-    ...libp2pDefaultOptions,
     services
   }
 }


### PR DESCRIPTION
Simplify default config generation, just return the fields we want to override instead of a whole config object.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
