### PR TITLE
fix: fall back to the filename extension for common media types

### DIFF
--- a/packages/verified-fetch/src/utils/content-type-parser.ts
+++ b/packages/verified-fetch/src/utils/content-type-parser.ts
@@ -60,8 +60,15 @@ export async function contentTypeParser (bytes: Uint8Array, fileName?: string): 
     return defaultMimeType
   }
 
-  // no need to include file-types listed at https://github.com/sindresorhus/file-type#supported-file-types
-  switch (fileName.split('.').pop()) {
+  // formats file-type cannot sniff at all, plus the media containers it only
+  // recognises when their magic bytes start at offset 0 - a file with leading
+  // padding (an MP3 whose first frame sync sits behind a run of silence, a PDF
+  // that does not begin with its header) reaches this switch as well, and
+  // `application/octet-stream` makes the browser download it instead of
+  // playing or displaying it inline
+  // @see https://github.com/sindresorhus/file-type#supported-file-types
+  // @see https://github.com/ipfs/service-worker-gateway/issues/1197
+  switch (fileName.split('.').pop()?.toLowerCase()) {
     case 'css':
       return 'text/css'
     case 'html':
@@ -74,13 +81,56 @@ export async function contentTypeParser (bytes: Uint8Array, fileName?: string): 
       return 'application/json'
     case 'txt':
       return 'text/plain'
+    case 'md':
+    case 'markdown':
+      return 'text/markdown'
+    case 'xml':
+      return 'text/xml; charset=utf-8'
+    case 'csv':
+      return 'text/csv'
+    case 'vtt':
+      return 'text/vtt'
     case 'woff2':
       return 'font/woff2'
     // see bottom of https://github.com/sindresorhus/file-type#supported-file-types
     case 'svg':
       return 'image/svg+xml'
-    case 'csv':
-      return 'text/csv'
+    case 'ico':
+      return 'image/x-icon'
+    case 'pdf':
+      return 'application/pdf'
+    case 'aac':
+      return 'audio/aac'
+    case 'flac':
+      return 'audio/flac'
+    case 'm4a':
+      return 'audio/mp4'
+    case 'mid':
+    case 'midi':
+      return 'audio/midi'
+    case 'mp3':
+      return 'audio/mpeg'
+    case 'oga':
+    case 'ogg':
+    case 'opus':
+      return 'audio/ogg'
+    case 'wav':
+      return 'audio/wav'
+    case 'weba':
+      return 'audio/webm'
+    case 'avi':
+      return 'video/x-msvideo'
+    case 'm4v':
+    case 'mp4':
+      return 'video/mp4'
+    case 'mkv':
+      return 'video/x-matroska'
+    case 'mov':
+      return 'video/quicktime'
+    case 'ogv':
+      return 'video/ogg'
+    case 'webm':
+      return 'video/webm'
     case 'doc':
       return 'application/msword'
     case 'xls':

--- a/packages/verified-fetch/test/content-type-parser.spec.ts
+++ b/packages/verified-fetch/test/content-type-parser.spec.ts
@@ -185,4 +185,92 @@ describe('content-type-parser', () => {
     const resp = await verifiedFetch.fetch(CID.parse('bafkqablimvwgy3y'))
     expect(resp.headers.get('content-type')).to.equal('text/plain')
   })
+
+  /**
+   * A single silent MPEG-1 Layer III frame - the `FF FB 90 00` sync word plus
+   * a zero-filled body, 417 bytes in total (the frame size for 128kbps @
+   * 44.1kHz).
+   */
+  function mp3Frame (): Uint8Array {
+    const frame = new Uint8Array(417)
+    frame.set([0xFF, 0xFB, 0x90, 0x00])
+
+    return frame
+  }
+
+  it('should detect mp3 as audio/mpeg when the frame sync is behind padding', async () => {
+    // file-type only recognises an MPEG frame sync at offset 0, so a file that
+    // opens with silence falls through to the filename extension
+    // @see https://github.com/ipfs/service-worker-gateway/issues/1197
+    const frame = mp3Frame()
+    const padded = new Uint8Array(frame.length * 2)
+    padded.set(frame, frame.length)
+
+    expect(await fileTypeFromBuffer(padded)).to.equal(undefined)
+
+    const result = await last(fs.addAll([{
+      path: '/audio.mp3',
+      content: padded
+    }], {
+      wrapWithDirectory: true
+    }))
+
+    verifiedFetch = new VerifiedFetch(helia)
+    const resp = await verifiedFetch.fetch(`ipfs://${result?.cid}/audio.mp3`)
+    expect(resp.headers.get('content-type')).to.equal('audio/mpeg')
+    expect(resp.headers.get('content-disposition')).to.include('filename="audio.mp3"')
+  })
+
+  it('should match the extension case-insensitively', async () => {
+    const frame = mp3Frame()
+    const padded = new Uint8Array(frame.length * 2)
+    padded.set(frame, frame.length)
+
+    const result = await last(fs.addAll([{
+      path: '/AUDIO.MP3',
+      content: padded
+    }], {
+      wrapWithDirectory: true
+    }))
+
+    verifiedFetch = new VerifiedFetch(helia)
+    const resp = await verifiedFetch.fetch(`ipfs://${result?.cid}/AUDIO.MP3`)
+    expect(resp.headers.get('content-type')).to.equal('audio/mpeg')
+  })
+
+  it('should prefer sniffed bytes over the filename extension', async () => {
+    // a PNG that happens to be named .mp3 is still a PNG
+    const png = new Uint8Array([
+      0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D,
+      0x49, 0x48, 0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+      0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00,
+      0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x62, 0x60, 0x01, 0x00, 0x00,
+      0x00, 0x05, 0x00, 0x01, 0xAA, 0xEE, 0xC4, 0x22, 0x00, 0x00, 0x00, 0x00,
+      0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82
+    ])
+
+    const result = await last(fs.addAll([{
+      path: '/not-audio.mp3',
+      content: png
+    }], {
+      wrapWithDirectory: true
+    }))
+
+    verifiedFetch = new VerifiedFetch(helia)
+    const resp = await verifiedFetch.fetch(`ipfs://${result?.cid}/not-audio.mp3`)
+    expect(resp.headers.get('content-type')).to.equal('image/png')
+  })
+
+  it('should detect md as text/markdown', async () => {
+    const result = await last(fs.addAll([{
+      path: '/readme.md',
+      content: uint8ArrayFromString('# hello\n')
+    }], {
+      wrapWithDirectory: true
+    }))
+
+    verifiedFetch = new VerifiedFetch(helia)
+    const resp = await verifiedFetch.fetch(`ipfs://${result?.cid}/readme.md`)
+    expect(resp.headers.get('content-type')).to.equal('text/markdown')
+  })
 })


### PR DESCRIPTION
## Problem

`contentTypeParser` sniffs with `file-type` first, which only looks for magic bytes at offset 0. A file that opens with padding is not recognised, so it falls through to the filename-extension switch — and that switch covers css, html, js, json, txt, woff2, svg, csv, doc, xls, ppt and msi only. Everything else becomes `application/octet-stream`, which browsers download instead of playing or displaying inline.

This was reported downstream in ipfs/service-worker-gateway#1197: two near-identical MP3s in the same directory, one plays and the other downloads. The one that downloads has 417 zero bytes before its first MPEG frame sync, so `fileTypeFromBuffer` returns `undefined` and `.mp3` is not in the switch.

The reference gateway does not have this problem — Kubo serves both files as `audio/mpeg`, because Go's `http.ServeContent` maps the extension first and only sniffs when the extension is unknown:

```console
$ curl -sI https://ipfs.io/ipfs/bafybeibce3vhbe6fn5jyiiyc7pzg2vxuqquxeigdqiuqxrt67f6yy3cwse/police.mp3 | grep -i content-type
Content-Type: audio/mpeg
```

## Change

- Adds the common audio (`mp3`, `m4a`, `aac`, `flac`, `wav`, `ogg`/`oga`/`opus`, `weba`, `mid`/`midi`), video (`mp4`, `m4v`, `webm`, `mkv`, `mov`, `avi`, `ogv`) and document (`pdf`, `ico`, `md`, `vtt`, `xml`) extensions to the switch. Several of these are formats `file-type` normally recognises — they are listed because sniffing is exactly what fails when the magic bytes are not at offset 0.
- Matches the extension case-insensitively, so `POLICE.MP3` resolves the same as `police.mp3`.

Sniffing still takes precedence, so a PNG named `.mp3` is unaffected — there is a test for that.

## Tests

Four cases added to `test/content-type-parser.spec.ts`: a padded MP3 (with an assertion that `fileTypeFromBuffer` really does give up on those bytes), the case-insensitive match, sniffed bytes winning over a misleading extension, and `.md`.

```
17 passing  (aegir test -t node --grep content-type-parser)
```

`aegir lint` and `aegir doc-check` are clean, and the package builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
